### PR TITLE
Fixed TensorFlow build command

### DIFF
--- a/scripts/docker_build_ml.sh
+++ b/scripts/docker_build_ml.sh
@@ -97,7 +97,7 @@ build_tensorflow()
 	echo "done building TensorFlow $tensorflow_whl, $tensorflow_tag"
 }
 
-if [[ "$CONTAINERS" == "pytorch" || "$CONTAINERS" == "all" ]]; then
+if [[ "$CONTAINERS" == "tensorflow" || "$CONTAINERS" == "all" ]]; then
 
 	# TensorFlow 1.15.2
 	build_tensorflow "https://nvidia.box.com/shared/static/8a3q3dz6juk0xg2e2kwwng9teosyohad.whl" \


### PR DESCRIPTION
Changed "pytorch" to "tensorflow".  Before the `./scripts/docker_build_ml.sh tensorflow` didn't do anything because there was nothing in the script to catch the `tensorflow` keyword.