### PR TITLE
Fix vision_msgs for foxy

### DIFF
--- a/Dockerfile.ros.foxy
+++ b/Dockerfile.ros.foxy
@@ -83,7 +83,7 @@ RUN mkdir -p ${ROS_ROOT}/src && \
     vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall
 
 # download unreleased packages     
-RUN git clone --branch ros2 https://github.com/Kukanani/vision_msgs ${ROS_ROOT}/src/vision_msgs && \
+RUN git clone --branch ${ROS_DISTRO} https://github.com/Kukanani/vision_msgs ${ROS_ROOT}/src/vision_msgs && \
     git clone --branch ${ROS_DISTRO} https://github.com/ros2/demos demos && \
     cp -r demos/demo_nodes_cpp ${ROS_ROOT}/src && \
     cp -r demos/demo_nodes_py ${ROS_ROOT}/src && \


### PR DESCRIPTION
Hi @dusty-nv 

I changed from ros2 -> foxy branch on https://github.com/Kukanani/vision_msgs 
It does make available the classification2D ros2 messages.

Best,
Raffaello