### PR TITLE
Update default base image to l4t-base:r32.4.4

### DIFF
--- a/Dockerfile.ml
+++ b/Dockerfile.ml
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.3
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.4
 ARG PYTORCH_IMAGE
 ARG TENSORFLOW_IMAGE
 
@@ -27,7 +27,7 @@ FROM ${TENSORFLOW_IMAGE} as tensorflow
 FROM ${BASE_IMAGE}
 
 
-# 
+#
 # setup environment
 #
 ENV DEBIAN_FRONTEND=noninteractive
@@ -89,8 +89,8 @@ RUN echo "$L4T_APT_SOURCE" > /etc/apt/sources.list.d/nvidia-l4t-apt-source.list 
 		  libopencv-python \
     && rm /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
     && rm -rf /var/lib/apt/lists/*
-    
-    
+
+
 #
 # python packages from TF/PyTorch containers
 #
@@ -104,7 +104,7 @@ COPY --from=pytorch /usr/local/lib/python3.6/dist-packages/ /usr/local/lib/pytho
 #
 # python pip packages
 #
-RUN pip3 install pybind11 --ignore-installed 
+RUN pip3 install pybind11 --ignore-installed
 RUN pip3 install onnx --verbose
 RUN pip3 install scipy --verbose
 RUN pip3 install scikit-learn --verbose
@@ -127,7 +127,7 @@ RUN pip3 install numba --verbose
 #    ln -s /usr/include/aarch64-linux-gnu/cudnn_ops_train_v8.h /usr/include/cudnn_ops_train.h && \
 #    ls -ll /usr/include/cudnn*
 
- 
+
 #
 # CuPy
 #
@@ -154,7 +154,7 @@ RUN pip3 install jupyter jupyterlab --verbose
 #RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager@2
 
 RUN jupyter lab --generate-config
-RUN python3 -c "from notebook.auth.security import set_password; set_password('nvidia', '/root/.jupyter/jupyter_notebook_config.json')" 
+RUN python3 -c "from notebook.auth.security import set_password; set_password('nvidia', '/root/.jupyter/jupyter_notebook_config.json')"
 
 CMD /bin/bash -c "jupyter lab --ip 0.0.0.0 --port 8888 --allow-root &> /var/log/jupyter.log" & \
 	echo "allow 10 sec for JupyterLab to start @ http://localhost:8888 (password nvidia)" && \

--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.3
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.4
 FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -49,7 +49,7 @@ RUN pip3 install numpy --verbose
 #  PyTorch v1.4.0 https://nvidia.box.com/shared/static/c3d7vm4gcs9m728j6o5vjay2jdedqb55.whl (torch-1.4.0-cp36-cp36m-linux_aarch64.whl)
 #  PyTorch v1.5.0 https://nvidia.box.com/shared/static/3ibazbiwtkl181n95n9em3wtrca7tdzp.whl (torch-1.5.0-cp36-cp36m-linux_aarch64.whl)
 #
-ARG PYTORCH_URL=https://nvidia.box.com/shared/static/lufbgr3xu2uha40cs9ryq1zn4kxsnogl.whl	
+ARG PYTORCH_URL=https://nvidia.box.com/shared/static/lufbgr3xu2uha40cs9ryq1zn4kxsnogl.whl
 ARG PYTORCH_WHL=torch-1.2.0-cp36-cp36m-linux_aarch64.whl
 
 RUN wget --quiet --show-progress --progress=bar:force:noscroll --no-check-certificate ${PYTORCH_URL} -O ${PYTORCH_WHL} && \
@@ -101,7 +101,7 @@ RUN git clone -b ${TORCHAUDIO_VERSION} https://github.com/pytorch/audio torchaud
     rm -rf torchaudio
 
 
-# 
+#
 # PyCUDA
 #
 ENV PATH="/usr/local/cuda/bin:${PATH}"

--- a/Dockerfile.ros.eloquent
+++ b/Dockerfile.ros.eloquent
@@ -2,7 +2,7 @@
 # this dockerfile roughly follows the 'Install ROS2 Via Debian Packages' from:
 #   https://index.ros.org/doc/ros2/Installation/Eloquent/Linux-Install-Debians/
 #
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.3
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.4
 FROM ${BASE_IMAGE}
 
 ARG ROS_PKG=ros_base
@@ -24,11 +24,11 @@ RUN apt-get update && \
 		cmake \
 		build-essential \
 		curl \
-		wget \ 
+		wget \
 		gnupg2 \
 		lsb-release \
     && rm -rf /var/lib/apt/lists/*
-    
+
 RUN wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc && apt-key add ros.asc
 RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
 
@@ -43,14 +43,14 @@ RUN apt-get update && \
 		python3-colcon-common-extensions \
 		python3-rosdep \
     && rm -rf /var/lib/apt/lists/*
-  
+
 # init/update rosdep
 RUN apt-get update && \
     cd ${ROS_ROOT} && \
     rosdep init && \
     rosdep update && \
     rm -rf /var/lib/apt/lists/*
-    
+
 # compile yaml-cpp-0.6, which some ROS packages may use (but is not in the 18.04 apt repo)
 RUN git clone --branch yaml-cpp-0.6.0 https://github.com/jbeder/yaml-cpp yaml-cpp-0.6 && \
     cd yaml-cpp-0.6 && \
@@ -63,7 +63,7 @@ RUN git clone --branch yaml-cpp-0.6.0 https://github.com/jbeder/yaml-cpp yaml-cp
 
 # setup entrypoint
 COPY ./packages/ros_entrypoint.sh /ros_entrypoint.sh
-RUN echo 'source ${ROS_ROOT}/setup.bash' >> /root/.bashrc 
+RUN echo 'source ${ROS_ROOT}/setup.bash' >> /root/.bashrc
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
 WORKDIR /

--- a/Dockerfile.ros.foxy
+++ b/Dockerfile.ros.foxy
@@ -2,7 +2,7 @@
 # this dockerfile roughly follows the 'Install ROS From Source' procedures from:
 #   https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/
 #
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.3
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.4
 FROM ${BASE_IMAGE}
 
 ARG ROS_PKG=ros_base
@@ -21,11 +21,11 @@ ENV LANG=en_US.UTF-8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
 		curl \
-		wget \ 
+		wget \
 		gnupg2 \
 		lsb-release \
     && rm -rf /var/lib/apt/lists/*
-    
+
 RUN wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc && apt-key add ros.asc
 RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
 
@@ -49,7 +49,7 @@ RUN apt-get update && \
 		libtinyxml2-dev \
 		libcunit1-dev \
     && rm -rf /var/lib/apt/lists/*
-  
+
 # install some pip packages needed for testing
 RUN python3 -m pip install -U \
 		argcomplete \
@@ -82,21 +82,22 @@ RUN mkdir -p ${ROS_ROOT}/src && \
     cat ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall
 
-# download unreleased packages     
+# download unreleased packages
 RUN git clone --branch ros2 https://github.com/Kukanani/vision_msgs ${ROS_ROOT}/src/vision_msgs && \
     git clone --branch ${ROS_DISTRO} https://github.com/ros2/demos demos && \
     cp -r demos/demo_nodes_cpp ${ROS_ROOT}/src && \
     cp -r demos/demo_nodes_py ${ROS_ROOT}/src && \
     rm -r -f demos
-    
+
 # install dependencies using rosdep
 RUN apt-get update && \
     cd ${ROS_ROOT} && \
     rosdep init && \
     rosdep update && \
-    rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers qt_gui" && \
+    # rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers qt_gui" && \
+    rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --skip-keys "" && \
     rm -rf /var/lib/apt/lists/*
-    
+
 # build it!
 RUN cd ${ROS_ROOT} && colcon build --symlink-install
 
@@ -108,7 +109,7 @@ RUN sed -i \
     /ros_entrypoint.sh && \
     cat /ros_entrypoint.sh
 
-RUN echo 'source ${ROS_ROOT}/install/setup.bash' >> /root/.bashrc 
+RUN echo 'source ${ROS_ROOT}/install/setup.bash' >> /root/.bashrc
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/Dockerfile.ros.melodic
+++ b/Dockerfile.ros.melodic
@@ -2,7 +2,7 @@
 # this dockerfile roughly follows the 'Ubuntu install of ROS Melodic' from:
 #   http://wiki.ros.org/melodic/Installation/Ubuntu
 #
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.3
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.4
 FROM ${BASE_IMAGE}
 
 ARG ROS_PKG=ros_base
@@ -20,11 +20,11 @@ RUN apt-get update && \
 		cmake \
 		build-essential \
 		curl \
-		wget \ 
+		wget \
 		gnupg2 \
 		lsb-release \
     && rm -rf /var/lib/apt/lists/*
-    
+
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
@@ -39,17 +39,17 @@ RUN apt-get update && \
           python-rosinstall-generator \
           python-wstool \
     && rm -rf /var/lib/apt/lists/*
-  
+
 # init/update rosdep
 RUN apt-get update && \
     cd ${ROS_ROOT} && \
     rosdep init && \
     rosdep update && \
     rm -rf /var/lib/apt/lists/*
-    
+
 # setup entrypoint
 COPY ./packages/ros_entrypoint.sh /ros_entrypoint.sh
-RUN echo 'source ${ROS_ROOT}/setup.bash' >> /root/.bashrc 
+RUN echo 'source ${ROS_ROOT}/setup.bash' >> /root/.bashrc
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
 WORKDIR /

--- a/Dockerfile.ros.noetic
+++ b/Dockerfile.ros.noetic
@@ -2,7 +2,7 @@
 # this dockerfile roughly follows the 'Installing from source' from:
 #   http://wiki.ros.org/noetic/Installation/Source
 #
-ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.3
+ARG BASE_IMAGE=nvcr.io/nvidia/l4t-base:r32.4.4
 FROM ${BASE_IMAGE}
 
 ARG ROS_PKG=ros_base
@@ -21,11 +21,11 @@ RUN apt-get update && \
 		cmake \
 		build-essential \
 		curl \
-		wget \ 
+		wget \
 		gnupg2 \
 		lsb-release \
     && rm -rf /var/lib/apt/lists/*
-    
+
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
@@ -54,7 +54,7 @@ RUN mkdir ros_catkin_ws && \
 
 # setup entrypoint
 COPY ./packages/ros_entrypoint.sh /ros_entrypoint.sh
-RUN echo 'source ${ROS_ROOT}/setup.bash' >> /root/.bashrc 
+RUN echo 'source ${ROS_ROOT}/setup.bash' >> /root/.bashrc
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]
 WORKDIR /

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -3,7 +3,7 @@
 CONTAINER=$1
 DOCKERFILE=$2
 
-shift 
+shift
 shift
 
 #sudo cp cuda-devel.csv /etc/nvidia-container-runtime/host-files-for-container.d/
@@ -11,4 +11,3 @@ shift
 echo "Building $CONTAINER container..."
 
 sudo docker build -t $CONTAINER -f $DOCKERFILE "$@" .
-

--- a/scripts/docker_build_ros.sh
+++ b/scripts/docker_build_ros.sh
@@ -4,26 +4,17 @@ set -e
 
 BASE_IMAGE="nvcr.io/nvidia/l4t-base"
 L4T_VERSION="r32.4.4"
+SUPPORTED_ROS_DISTROS=("melodic" "noetic" "eloquent" "foxy")
 ROS_DISTRO=${1:-"all"}
 
 echo "building containers for $ROS_DISTRO..."
 
-# ROS Melodic
-if [[ "$ROS_DISTRO" == "melodic" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:melodic-ros-base-l4t-$L4T_VERSION Dockerfile.ros.melodic --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
+if [[ "$ROS_DISTRO" == "all" ]]; then
+	TO_BUILD=${SUPPORTED_ROS_DISTROS[@]}
+else
+	TO_BUILD=($ROS_DISTRO)
 fi
 
-# ROS Noetic
-if [[ "$ROS_DISTRO" == "noetic" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:noetic-ros-base-l4t-$L4T_VERSION Dockerfile.ros.noetic --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
-fi
-
-# ROS2 Eloquent
-if [[ "$ROS_DISTRO" == "eloquent" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:eloquent-ros-base-l4t-$L4T_VERSION Dockerfile.ros.eloquent --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
-fi
-
-# ROS2 Foxy
-if [[ "$ROS_DISTRO" == "foxy" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:foxy-ros-base-l4t-$L4T_VERSION Dockerfile.ros.foxy --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
-fi
+for DISTRO in ${TO_BUILD[@]}; do
+	sh ./scripts/docker_build.sh ros:$DISTRO-ros-base-l4t-$L4T_VERSION Dockerfile.ros.$DISTRO --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
+done

--- a/scripts/docker_build_ros.sh
+++ b/scripts/docker_build_ros.sh
@@ -2,28 +2,28 @@
 
 set -e
 
-BASE_IMAGE="nvcr.io/nvidia/l4t-base:r32.4.3"
+BASE_IMAGE="nvcr.io/nvidia/l4t-base"
+L4T_VERSION="r32.4.4"
 ROS_DISTRO=${1:-"all"}
 
 echo "building containers for $ROS_DISTRO..."
 
 # ROS Melodic
 if [[ "$ROS_DISTRO" == "melodic" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:melodic-ros-base-l4t-r32.4.3 Dockerfile.ros.melodic --build-arg BASE_IMAGE=$BASE_IMAGE
+	sh ./scripts/docker_build.sh ros:melodic-ros-base-l4t-$L4T_VERSION Dockerfile.ros.melodic --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
 fi
 
 # ROS Noetic
 if [[ "$ROS_DISTRO" == "noetic" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:noetic-ros-base-l4t-r32.4.3 Dockerfile.ros.noetic --build-arg BASE_IMAGE=$BASE_IMAGE
+	sh ./scripts/docker_build.sh ros:noetic-ros-base-l4t-$L4T_VERSION Dockerfile.ros.noetic --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
 fi
 
 # ROS2 Eloquent
 if [[ "$ROS_DISTRO" == "eloquent" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:eloquent-ros-base-l4t-r32.4.3 Dockerfile.ros.eloquent --build-arg BASE_IMAGE=$BASE_IMAGE
+	sh ./scripts/docker_build.sh ros:eloquent-ros-base-l4t-$L4T_VERSION Dockerfile.ros.eloquent --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
 fi
 
 # ROS2 Foxy
 if [[ "$ROS_DISTRO" == "foxy" || "$ROS_DISTRO" == "all" ]]; then
-	sh ./scripts/docker_build.sh ros:foxy-ros-base-l4t-r32.4.3 Dockerfile.ros.foxy --build-arg BASE_IMAGE=$BASE_IMAGE
+	sh ./scripts/docker_build.sh ros:foxy-ros-base-l4t-$L4T_VERSION Dockerfile.ros.foxy --build-arg BASE_IMAGE=$BASE_IMAGE:$L4T_VERSION
 fi
-

--- a/scripts/docker_test_ros.sh
+++ b/scripts/docker_test_ros.sh
@@ -5,6 +5,7 @@ set -e
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TEST_MOUNT="$ROOT/../test:/test"
 ROS_DISTRO=${1:-"all"}
+L4T_VERSION="r32.4.4"
 
 test_ros_version()
 {
@@ -22,20 +23,20 @@ test_ros2_version()
 
 # Melodic
 if [[ "$ROS_DISTRO" == "melodic" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros_version "ros:melodic-ros-base-l4t-r32.4.3"
+	test_ros_version "ros:melodic-ros-base-l4t-$L4T_VERSION"
 fi
 
 # Noetic
 if [[ "$ROS_DISTRO" == "noetic" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros_version "ros:noetic-ros-base-l4t-r32.4.3"
+	test_ros_version "ros:noetic-ros-base-l4t-$L4T_VERSION"
 fi
 
 # Eloquent
 if [[ "$ROS_DISTRO" == "eloquent" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros2_version "ros:eloquent-ros-base-l4t-r32.4.3"
+	test_ros2_version "ros:eloquent-ros-base-l4t-$L4T_VERSION"
 fi
 
 # Foxy
 if [[ "$ROS_DISTRO" == "foxy" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros2_version "ros:foxy-ros-base-l4t-r32.4.3"
+	test_ros2_version "ros:foxy-ros-base-l4t-$L4T_VERSION"
 fi

--- a/scripts/docker_test_ros.sh
+++ b/scripts/docker_test_ros.sh
@@ -4,39 +4,28 @@ set -e
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TEST_MOUNT="$ROOT/../test:/test"
-ROS_DISTRO=${1:-"all"}
 L4T_VERSION="r32.4.4"
+SUPPORTED_ROS_DISTROS=("melodic" "noetic" "eloquent" "foxy")
+ROS_DISTRO=${1:-"all"}
 
 test_ros_version()
 {
 	echo "testing container $1 => ros_version"
-	sh ./scripts/docker_run.sh -c $1 -v $TEST_MOUNT -r test/test_ros_version.sh
+	local DISTRO_TO_TEST=$(echo "$1" | cut -d ":" -f 2 | cut -d "-" -f 1)
+	if [[ "$DISTRO_TO_TEST" == "melodic" || "$DISTRO_TO_TEST" == "noetic" ]]; then
+		sh ./scripts/docker_run.sh -c $1 -v $TEST_MOUNT -r test/test_ros_version.sh
+	else
+		sh ./scripts/docker_run.sh -c $1 -v $TEST_MOUNT -r test/test_ros2_version.sh
+	fi
 	echo -e "done testing container $1 => ros_version\n"
 }
 
-test_ros2_version()
-{
-	echo "testing container $1 => ros2_version"
-	sh ./scripts/docker_run.sh -c $1 -v $TEST_MOUNT -r test/test_ros2_version.sh
-	echo -e "done testing container $1 => ros_version\n"
-}
-
-# Melodic
-if [[ "$ROS_DISTRO" == "melodic" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros_version "ros:melodic-ros-base-l4t-$L4T_VERSION"
+if [[ "$ROS_DISTRO" == "all" ]]; then
+	TO_TEST=${SUPPORTED_ROS_DISTROS[@]}
+else
+	TO_TEST=($ROS_DISTRO)
 fi
 
-# Noetic
-if [[ "$ROS_DISTRO" == "noetic" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros_version "ros:noetic-ros-base-l4t-$L4T_VERSION"
-fi
-
-# Eloquent
-if [[ "$ROS_DISTRO" == "eloquent" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros2_version "ros:eloquent-ros-base-l4t-$L4T_VERSION"
-fi
-
-# Foxy
-if [[ "$ROS_DISTRO" == "foxy" || "$ROS_DISTRO" == "all" ]]; then
-	test_ros2_version "ros:foxy-ros-base-l4t-$L4T_VERSION"
-fi
+for DISTRO in ${TO_TEST[@]}; do
+	test_ros_version "ros:$DISTRO-ros-base-l4t-$L4T_VERSION"
+done


### PR DESCRIPTION
This PR update all the Docker files to use the latest `l4t-base` image, `r32.4.4`, as a base by default. It also introduces a few changes to the `ROS` related scripts. 