### PR TITLE
[ROS] Update GPG key installation step to the latest

### DIFF
--- a/Dockerfile.ros.eloquent
+++ b/Dockerfile.ros.eloquent
@@ -29,8 +29,8 @@ RUN apt-get update && \
 		lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc && apt-key add ros.asc
-RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 # install ROS packages
 RUN apt-get update && \

--- a/Dockerfile.ros.foxy
+++ b/Dockerfile.ros.foxy
@@ -26,8 +26,8 @@ RUN apt-get update && \
 		lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget --no-check-certificate https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc && apt-key add ros.asc
-RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 # install development packages
 RUN apt-get update && \


### PR DESCRIPTION
Some of the ROS installation instructions have been updated.
This PR updates the GPG key installation step to the latest.

ref: https://github.com/ros2/ros2_documentation/pull/1189
