### PR TITLE
Update for JetPack 4.5.2

### DIFF
--- a/scripts/docker_base.sh
+++ b/scripts/docker_base.sh
@@ -17,6 +17,8 @@ if [ $L4T_RELEASE -eq 32 ]; then
 			BASE_IMAGE="nvcr.io/nvidia/l4t-base:r32.5.0"
 		elif [ $L4T_REVISION_MINOR -gt 1 ]; then
 			BASE_IMAGE=$BASE_DEVEL
+		elif [ $L4T_REVISION_MINOR -gt 2 ]; then
+			BASE_IMAGE=$BASE_DEVEL
 		fi
 	elif [ $L4T_REVISION_MAJOR -gt 6 ]; then
 		BASE_IMAGE=$BASE_DEVEL

--- a/scripts/docker_base.sh
+++ b/scripts/docker_base.sh
@@ -13,6 +13,8 @@ if [ $L4T_RELEASE -eq 32 ]; then
 	elif [ $L4T_REVISION_MAJOR -eq 5 ]; then
 		if [ $L4T_REVISION_MINOR -eq 1 ]; then
 			BASE_IMAGE="nvcr.io/nvidia/l4t-base:r32.5.0"
+		elif [ $L4T_REVISION_MINOR -eq 2 ]; then
+			BASE_IMAGE="nvcr.io/nvidia/l4t-base:r32.5.0"
 		elif [ $L4T_REVISION_MINOR -gt 1 ]; then
 			BASE_IMAGE=$BASE_DEVEL
 		fi


### PR DESCRIPTION
Yesterdays automatic update of 4.5.1 to 4.5.2 breaks the docker_base script in a similar way to the 4.6.0 to 4.6.1 update did.