### PR TITLE
Fixing spelling error in link

### DIFF
--- a/scripts/docker_base.sh
+++ b/scripts/docker_base.sh
@@ -3,7 +3,7 @@
 source scripts/l4t_version.sh
 
 BASE_IMAGE="nvcr.io/nvidia/l4t-base:r$L4T_VERSION"
-BASE_DEVEL="nvcr.io/nvidian/nvidia-l4t-base:r$L4T_VERSION"
+BASE_DEVEL="nvcr.io/nvidia/nvidia-l4t-base:r$L4T_VERSION"
 
 if [ $L4T_RELEASE -eq 32 ]; then
 	if [ $L4T_REVISION_MAJOR -eq 4 ]; then

--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CONTAINER_IMAGE="nvcr.io/nvidian/nvidia-l4t-base:r32.4"
+CONTAINER_IMAGE="nvcr.io/nvidia/nvidia-l4t-base:r32.4"
 
 USER_VOLUME=""
 USER_COMMAND=""


### PR DESCRIPTION
Fixing a spelling error in the nvidia cloud link which gives errors when running the scripts if the base-image doesnt already exist locally.