### PR TITLE
Fix cmake version

### DIFF
--- a/Dockerfile.ros.foxy
+++ b/Dockerfile.ros.foxy
@@ -22,7 +22,6 @@ ENV LANG=en_US.UTF-8
 ENV PYTHONIOENCODING=utf-8
 
 
-
 # 
 # add the ROS deb repo to the apt sources list
 #
@@ -33,7 +32,6 @@ RUN apt-get update && \
 		gnupg2 \
 		lsb-release \
 		ca-certificates \
-		python3-pip \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -42,45 +40,18 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/r
 
 
 # 
-# upgrade cmake - https://stackoverflow.com/a/56690743
-# this is needed to build some of the ROS2 packages
-#
-#RUN apt-get update && \
-#    apt-get install -y --no-install-recommends \
-#		  software-properties-common \
-#		  apt-transport-https \
-#		  ca-certificates \
-#		  gnupg \
-#		  lsb-release \
-#    && rm -rf /var/lib/apt/lists/* \
-#    && apt-get clean
-		  	  
-#RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
-#    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
-#    apt-get update && \
-#    apt-get install -y --no-install-recommends --only-upgrade \
-#            cmake \
-#    && rm -rf /var/lib/apt/lists/* \
-#    && apt-get clean
-
-# workaround for https://github.com/dusty-nv/jetson-containers/issues/181
-RUN apt purge -y cmake && \
-    pip3 install cmake==3.23.3 --upgrade --verbose 
-    
-RUN cmake --version
-
-
-# 
 # install development packages
 #
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
 		build-essential \
+		cmake \
 		git \
 		libbullet-dev \
 		libpython3-dev \
 		python3-colcon-common-extensions \
 		python3-flake8 \
+		python3-pip \
 		python3-numpy \
 		python3-pytest-cov \
 		python3-rosdep \
@@ -131,6 +102,31 @@ RUN apt-get purge -y '*opencv*' || echo "previous OpenCV installation not found"
     cp -r /usr/include/opencv4 /usr/local/include/opencv4 && \
     cp -r /usr/lib/python${PYTHON3_VERSION}/dist-packages/cv2 /usr/local/lib/python${PYTHON3_VERSION}/dist-packages/cv2
 	
+
+# 
+# upgrade cmake - https://stackoverflow.com/a/56690743
+# this is needed to build some of the ROS2 packages
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+		  software-properties-common \
+		  apt-transport-https \
+		  ca-certificates \
+		  gnupg \
+		  lsb-release \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+		  	  
+RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
+    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends --only-upgrade \
+            cmake \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+    
+RUN cmake --version
+
 
 # 
 # compile yaml-cpp-0.6, which some ROS packages may use (but is not in the 18.04 apt repo)

--- a/Dockerfile.ros.foxy
+++ b/Dockerfile.ros.foxy
@@ -170,7 +170,8 @@ RUN mkdir -p ${ROS_ROOT}/src && \
 		> ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     cat ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
-    
+    rm -r ${ROS_ROOT}/src/ament_cmake && \
+    git -C ${ROS_ROOT}/src/ clone https://github.com/ament/ament_cmake -b ${ROS_DISTRO} && \
     # install dependencies using rosdep
     apt-get update && \
     cd ${ROS_ROOT} && \

--- a/Dockerfile.ros.galactic
+++ b/Dockerfile.ros.galactic
@@ -156,6 +156,8 @@ RUN mkdir -p ${ROS_ROOT}/src && \
 		> ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     cat ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
+    rm -r ${ROS_ROOT}/src/ament_cmake && \
+    git -C ${ROS_ROOT}/src/ clone https://github.com/ament/ament_cmake -b ${ROS_DISTRO} && \
 
     # install dependencies using rosdep
     apt-get update && \

--- a/Dockerfile.ros.galactic
+++ b/Dockerfile.ros.galactic
@@ -32,41 +32,11 @@ RUN apt-get update && \
 		gnupg2 \
 		lsb-release \
 		ca-certificates \
-		python3-pip \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
-
-# 
-# upgrade cmake - https://stackoverflow.com/a/56690743
-# this is needed to build some of the ROS2 packages
-#
-#RUN apt-get update && \
-#    apt-get install -y --no-install-recommends \
-#		  software-properties-common \
-#		  apt-transport-https \
-#		  ca-certificates \
-#		  gnupg \
-#		  lsb-release \
-#    && rm -rf /var/lib/apt/lists/* \
-#    && apt-get clean
-		  	  
-#RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
-#    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
-#    apt-get update && \
-#    apt-get install -y --no-install-recommends --only-upgrade \
-#            cmake \
-#    && rm -rf /var/lib/apt/lists/* \
-#    && apt-get clean
-
-# workaround for https://github.com/dusty-nv/jetson-containers/issues/181
-RUN apt purge -y cmake && \
-    pip3 install cmake==3.23.3 --upgrade --verbose 
-    
-RUN cmake --version
 
 
 # 
@@ -133,6 +103,30 @@ RUN apt-get purge -y '*opencv*' || echo "previous OpenCV installation not found"
     cp -r /usr/lib/python${PYTHON3_VERSION}/dist-packages/cv2 /usr/local/lib/python${PYTHON3_VERSION}/dist-packages/cv2
     
     
+# 
+# upgrade cmake - https://stackoverflow.com/a/56690743
+# this is needed to build some of the ROS2 packages
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+		  software-properties-common \
+		  apt-transport-https \
+		  ca-certificates \
+		  gnupg \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+		  	  
+RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
+    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends --only-upgrade \
+            cmake \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+    
+RUN cmake --version
+
+
 # 
 # download/build ROS from source
 #

--- a/Dockerfile.ros.humble
+++ b/Dockerfile.ros.humble
@@ -159,6 +159,8 @@ RUN mkdir -p ${ROS_ROOT}/src && \
 		> ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     cat ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
+    rm -r ${ROS_ROOT}/src/ament_cmake && \
+    git -C ${ROS_ROOT}/src/ clone https://github.com/ament/ament_cmake -b ${ROS_DISTRO} && \
 
     # install dependencies using rosdep
     apt-get update && \


### PR DESCRIPTION
This [patch](https://github.com/dusty-nv/jetson-containers/commit/a7a878e6f3995dbc25acd710127156b4fae5a2aa) didn't work for us but we have a particular setup, it might work for others. Nevertheless I wanted to propose the fix that worked for us, that might actually be cleaner than the original patch in two ways:

1- no need for pip
2- hold cmake to this version to avoid accidental upgrade 
