### PR TITLE
Fix invalid regex

### DIFF
--- a/scripts/opencv_install.sh
+++ b/scripts/opencv_install.sh
@@ -14,7 +14,7 @@ ARCH=$(uname -i)
 echo "ARCH:  $ARCH"
 
 # remove previous OpenCV installation if it exists
-apt-get purge -y '*opencv*' || echo "previous OpenCV installation not found"
+apt-get purge -y '.*opencv.*' || echo "previous OpenCV installation not found"
 
 # download and extract the deb packages
 mkdir opencv


### PR DESCRIPTION
Before:
```
root@2f4f74e5381b:/tmp# apt-get purge -y '*opencv*'
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package *opencv*
E: Couldn't find any package by glob '*opencv*'
E: Regex compilation error - Invalid preceding regular expression
E: Couldn't find any package by regex '*opencv*'
```

After
```
root@2f4f74e5381b:/tmp# apt-get purge -y '.*opencv.*'
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package .*opencv.*
E: Couldn't find any package by glob '.*opencv.*'
E: Couldn't find any package by regex '.*opencv.*'
```