### PR TITLE
docker_test_ml: remove tf1.15 for JP5.1

### DIFF
--- a/scripts/docker_test_ml.sh
+++ b/scripts/docker_test_ml.sh
@@ -206,7 +206,7 @@ fi
 # TensorFlow container
 #
 if [[ "$CONTAINERS" == "tensorflow" || "$CONTAINERS" == "all" ]]; then
-	test_tensorflow_all "l4t-tensorflow:r$L4T_VERSION-tf1.15-py3"
+	#test_tensorflow_all "l4t-tensorflow:r$L4T_VERSION-tf1.15-py3"
 	test_tensorflow_all "l4t-tensorflow:r$L4T_VERSION-tf2.11-py3"
 fi
 


### PR DESCRIPTION
Add a comment on the line for l4t-tensorflow tf1.15-py3 since this tag does not exist (see https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-tensorflow/tags) for latest r35.2.1 L4T release
