### PR TITLE
Point to r32.7.1 l4t-base image for all L4T 32.7.* versions

### DIFF
--- a/scripts/docker_base.sh
+++ b/scripts/docker_base.sh
@@ -19,6 +19,10 @@ if [ $ARCH = "aarch64" ]; then
 			elif [ $L4T_REVISION_MINOR -gt 2 ]; then
 				BASE_IMAGE=$BASE_DEVEL
 			fi
+		elif [ $L4T_REVISION_MAJOR -eq 7 ]; then
+			if [ $L4T_REVISION_MINOR -ne 1 ]; then
+				BASE_IMAGE="nvcr.io/nvidia/l4t-base:r32.7.1"
+			fi
 		elif [ $L4T_REVISION_MAJOR -gt 7 ]; then
 			BASE_IMAGE=$BASE_DEVEL
 		fi


### PR DESCRIPTION
Modified `scripts/docker_base.sh` to force the use of the 32.7.1 base l4t base image for all 32.7.* l4t versions. This is because there are no other 32.7.* base images except for `nvcr.io/nvidia/l4t-base:r32.7.1`, so using `$L4T_VERSION` doesn't work.