### PR TITLE
Introduce `--no-github-api` option for `build.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data
 logs
 test/data
 runner
+*.minus-github-api

--- a/docs/build.md
+++ b/docs/build.md
@@ -81,3 +81,19 @@ These flags tend to get used more during development - normally it's good to tho
 ## Running Containers
 
 To launch containers that you've built or pulled, see the [Running Containers](/docs/run.md) documentation or the package's readme page.
+
+## Troubleshooting
+
+When building a container, you may hit this GitHub API rate limit especially if you are working in an office environment or similar where your outward-facing IP address is shared with other developers/instances.
+
+> ADD failed: failed to GET https://api.github.com/repos/abetlen/llama-cpp-python/git/refs/heads/main with status 403 Forbidden: {"message":"API rate limit exceeded for 216.228.112.22. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
+
+If that is the case, use `--no-github-api` to remove a line like below from `Dockerfile` that was added to force rebuild on new git commits.
+
+```
+ADD https://api.github.com/repos/${LLAMA_CPP_PYTHON_REPO}/git/refs/heads/${LLAMA_CPP_PYTHON_BRANCH} /tmp/llama_cpp_python_version.json
+```
+
+You will find `Dockerfile.minus-github-api` file newly created in each package directory if the Dockerfile contains such line, and that's what used for building.
+
+The `Dockerfile.minus-github-api` is temporary (and is listed in `.gitignore`), so always edit the original `Dockerfile` when needed.

--- a/docs/build.md
+++ b/docs/build.md
@@ -88,7 +88,13 @@ When building a container, you may hit this GitHub API rate limit especially if 
 
 > ADD failed: failed to GET https://api.github.com/repos/abetlen/llama-cpp-python/git/refs/heads/main with status 403 Forbidden: {"message":"API rate limit exceeded for 216.228.112.22. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
 
-If that is the case, use `--no-github-api` to remove a line like below from `Dockerfile` that was added to force rebuild on new git commits.
+If that is the case, use `--no-github-api` option when running `build.sh`
+
+```
+./build.sh --no-github-api --skip-test=all text-generation-webui
+```
+
+The option `--no-github-api` is to remove a line like below from `Dockerfile` that was added to force rebuild on new git commits.
 
 ```
 ADD https://api.github.com/repos/${LLAMA_CPP_PYTHON_REPO}/git/refs/heads/${LLAMA_CPP_PYTHON_BRANCH} /tmp/llama_cpp_python_version.json

--- a/docs/build.md
+++ b/docs/build.md
@@ -103,3 +103,7 @@ ADD https://api.github.com/repos/${LLAMA_CPP_PYTHON_REPO}/git/refs/heads/${LLAMA
 You will find `Dockerfile.minus-github-api` file newly created in each package directory if the Dockerfile contains such line, and that's what used for building.
 
 The `Dockerfile.minus-github-api` is temporary (and is listed in `.gitignore`), so always edit the original `Dockerfile` when needed.
+
+If you want to remove all such temporary files, you can execute the following command.
+
+> `find . -type f -name *.minus-github-api -delete`

--- a/jetson_containers/build.py
+++ b/jetson_containers/build.py
@@ -48,6 +48,7 @@ parser.add_argument('--test-only', type=str, default='', help="only test the spe
 parser.add_argument('--simulate', action='store_true', help="print out the build commands without actually building the containers")
 parser.add_argument('--push', type=str, default='', help="repo or user to push built container image to (no push by default)")
 parser.add_argument('--logs', type=str, default='', help="sets the directory to save container build logs to (default: jetson-containers/logs)")
+parser.add_argument('--no-github-api', action='store_true', help="disalbe Github API use to force rebuild on new git commits")
 
 args = parser.parse_args()
 
@@ -92,6 +93,6 @@ if args.list_packages or args.show_packages:
 # build one multi-stage container from chain of packages
 # or launch multiple independent container builds
 if not args.multiple:
-    build_container(args.name, args.packages, args.base, args.build_flags, args.simulate, args.skip_tests, args.test_only, args.push)
+    build_container(args.name, args.packages, args.base, args.build_flags, args.simulate, args.skip_tests, args.test_only, args.push, args.no_github_api)
 else:   
-    build_containers(args.name, args.packages, args.base, args.build_flags, args.simulate, args.skip_errors, args.skip_packages, args.skip_tests, args.test_only, args.push)
+    build_containers(args.name, args.packages, args.base, args.build_flags, args.simulate, args.skip_errors, args.skip_packages, args.skip_tests, args.test_only, args.push, args.no_github_api)


### PR DESCRIPTION
When building a container, you may hit the GitHub API rate limit error especially if you are working in an office environment.
This option removes the `ADD https://api.github.com/repos/` from each package's Dockerfile.