### PR TITLE
Add submodule to build PyTorch 2.0 built with USE_DISTRIBUTED=1

### DIFF
--- a/packages/pytorch/Dockerfile.2.0_use_distributed
+++ b/packages/pytorch/Dockerfile.2.0_use_distributed
@@ -1,0 +1,56 @@
+# 
+# this is the pytorch:2-0_rebuilt container (built in parallel with pytorch:)
+# see Dockerfile & config.py for package configuration/metadata
+#
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+WORKDIR /opt/
+
+# install prerequisites
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+		  libopenblas-dev \
+		  libopenmpi-dev \
+            openmpi-bin \
+            openmpi-common \
+		  gfortran \
+		  libomp-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN git clone --recursive --branch v2.0.1 http://github.com/pytorch/pytorch && \
+    cd pytorch && \
+    export USE_NCCL=0 && \
+    export USE_DISTRIBUTED=1 && \
+    export USE_QNNPACK=0 && \
+    export USE_PYTORCH_QNNPACK=0 && \
+    export TORCH_CUDA_ARCH_LIST="7.2;8.7" && \
+    export USE_NATIVE_ARCH=1 && \
+    export PYTORCH_BUILD_VERSION="2.0.1" && \
+    export PYTORCH_BUILD_NUMBER=1 && \
+    apt-get install python3-pip libopenblas-dev libopenmpi-dev
+RUN cd /opt/pytorch && \    
+    pip3 install -r requirements.txt && \
+    pip3 install scikit-build && \
+    pip3 install ninja && \
+    python3 setup.py bdist_wheel 
+RUN cd /opt/pytorch && \    
+    ls -lh && \
+    find ./ -name *.whl &&\
+    pip3 install --verbose ./dist/*.whl
+
+RUN python3 -c 'import torch; print(f"PyTorch version: {torch.__version__}"); print(f"CUDA available:  {torch.cuda.is_available()}"); print(f"cuDNN version:   {torch.backends.cudnn.version()}"); print(f"torch.distributed:   {torch.distributed.is_available()}"); print(torch.__config__.show());'
+
+# patch for https://github.com/pytorch/pytorch/issues/45323
+RUN PYTHON_ROOT=`pip3 show torch | grep Location: | cut -d' ' -f2` && \
+    TORCH_CMAKE_CONFIG=$PYTHON_ROOT/torch/share/cmake/Torch/TorchConfig.cmake && \
+    echo "patching _GLIBCXX_USE_CXX11_ABI in ${TORCH_CMAKE_CONFIG}" && \
+    sed -i 's/  set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=")/  set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0")/g' ${TORCH_CMAKE_CONFIG}
+
+# # PyTorch C++ extensions frequently use ninja parallel builds
+# RUN pip3 install --no-cache-dir scikit-build && \
+#     pip3 install --no-cache-dir ninja
+    
+# set the torch hub model cache directory to mounted /data volume
+ENV TORCH_HOME=/data/models/torch

--- a/packages/pytorch/config.py
+++ b/packages/pytorch/config.py
@@ -23,6 +23,10 @@ def pytorch(version, whl, url, requires, default=False):
     
     return pkg
     
+extra_pkg = package.copy()
+extra_pkg['name'] = 'pytorch:2.0_use_distributed'
+extra_pkg['dockerfile'] = 'Dockerfile.2.0_use_distributed'
+extra_pkg['depends'] = ['python', 'numpy', 'onnx']
     
 package = [
     # JetPack 5
@@ -35,5 +39,6 @@ package = [
     # JetPack 4
     #pytorch('1.11', 'torch-1.11.0a0+17540c5-cp36-cp36m-linux_aarch64.whl', 'https://developer.download.nvidia.com/compute/redist/jp/v461/pytorch/torch-1.11.0a0+17540c5+nv22.01-cp36-cp36m-linux_aarch64.whl', '==32.*'),  # (built without LAPACK support)
     pytorch('1.10', 'torch-1.10.0-cp36-cp36m-linux_aarch64.whl', 'https://nvidia.box.com/shared/static/fjtbno0vpo676a25cgvuqc1wty0fkkg6.whl', '==32.*', default=True),
-    pytorch('1.9', 'torch-1.9.0-cp36-cp36m-linux_aarch64.whl', 'https://nvidia.box.com/shared/static/h1z9sw4bb1ybi0rm3tu8qdj8hs05ljbm.whl', '==32.*')
+    pytorch('1.9', 'torch-1.9.0-cp36-cp36m-linux_aarch64.whl', 'https://nvidia.box.com/shared/static/h1z9sw4bb1ybi0rm3tu8qdj8hs05ljbm.whl', '==32.*'),
+    extra_pkg
 ]


### PR DESCRIPTION
`torch.distributed` module is needed by `mmcv` which is used by Track Anything.

This is to add `pytorch:2.0_use_distributed` sub-package.