### PR TITLE
Use entrypoint style for end-user app

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -295,7 +295,7 @@ def test_container(name, package, simulate=False):
         cmd += f"--volume {package['path']}:/test" + _NEWLINE_
         cmd += f"--volume {os.path.join(_PACKAGE_ROOT, 'data')}:/data" + _NEWLINE_
         cmd += f"--workdir /test" + _NEWLINE_
-        cmd += f"--entrypoint ''" + _NEWLINE_
+        cmd += f"--entrypoint /usr/bin/env" + _NEWLINE_
         cmd += name + _NEWLINE_
         
         cmd += "/bin/bash -c '"

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -295,6 +295,7 @@ def test_container(name, package, simulate=False):
         cmd += f"--volume {package['path']}:/test" + _NEWLINE_
         cmd += f"--volume {os.path.join(_PACKAGE_ROOT, 'data')}:/data" + _NEWLINE_
         cmd += f"--workdir /test" + _NEWLINE_
+        cmd += f"--entrypoint ''" + _NEWLINE_
         cmd += name + _NEWLINE_
         
         cmd += "/bin/bash -c '"

--- a/packages/audio/riva-client/Dockerfile.python
+++ b/packages/audio/riva-client/Dockerfile.python
@@ -39,5 +39,4 @@ RUN pip3 show nvidia-riva-client && python3 -c 'import riva.client; print(riva.c
 COPY list_audio_devices.py python-clients/scripts/
 COPY loopback.py python-clients/scripts/
 
-
 WORKDIR /

--- a/packages/diffusion/stable-diffusion-webui/Dockerfile
+++ b/packages/diffusion/stable-diffusion-webui/Dockerfile
@@ -34,6 +34,8 @@ RUN cd /opt/stable-diffusion-webui && \
 # set the cache dir for models
 ENV DIFFUSERS_CACHE=/data/models/diffusers
 
-# default start-up command
-CMD /bin/bash -c "cd /opt/stable-diffusion-webui && python3 launch.py --data=/data/models/stable-diffusion --enable-insecure-extension-access --xformers --listen --port=7860"
+COPY docker-entrypoint.sh /usr/local/bin
 
+WORKDIR /opt/stable-diffusion-webui
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packages/diffusion/stable-diffusion-webui/docker-entrypoint.sh
+++ b/packages/diffusion/stable-diffusion-webui/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd /opt/stable-diffusion-webui && python3 launch.py --data=/data/models/stable-diffusion --enable-insecure-extension-access --xformers --listen --port=7860 "$@"

--- a/packages/jupyterlab/Dockerfile
+++ b/packages/jupyterlab/Dockerfile
@@ -14,7 +14,8 @@ RUN pip3 install --no-cache-dir --verbose jupyter 'jupyterlab<4' && \
 RUN jupyter lab --version && jupyter lab --generate-config
 RUN python3 -c "from notebook.auth.security import set_password; set_password('nvidia', '/root/.jupyter/jupyter_notebook_config.json')"
 
-CMD /bin/bash -c "jupyter lab --ip 0.0.0.0 --port 8888 --allow-root &> /var/log/jupyter.log" & \
-	echo "allow 10 sec for JupyterLab to start @ http://$(hostname -I | cut -d' ' -f1):8888 (password nvidia)" && \
-	echo "JupterLab logging location:  /var/log/jupyter.log  (inside the container)" && \
-	/bin/bash
+COPY docker-entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/packages/jupyterlab/docker-entrypoint.sh
+++ b/packages/jupyterlab/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+jupyter lab --ip 0.0.0.0 --port 8888 --allow-root &> /var/log/jupyter.log &
+echo "allow 10 sec for JupyterLab to start @ http://$(hostname -I | cut -d' ' -f1):8888 (password nvidia)"
+
+echo "JupterLab logging location:  /var/log/jupyter.log  (inside the container)"
+exec "$@"

--- a/packages/llm/text-generation-webui/Dockerfile
+++ b/packages/llm/text-generation-webui/Dockerfile
@@ -79,6 +79,8 @@ ENV LD_PRELOAD=${LD_PRELOAD}:${LD_PRELOAD_LIBS}
 
 COPY settings.json text-generation-webui/
 
-WORKDIR /
+COPY docker-entrypoint.sh /usr/local/bin
 
-CMD /bin/bash -c "cd /opt/text-generation-webui && python3 server.py --model-dir=/data/models/text-generation-webui --listen --verbose"
+WORKDIR /opt/text-generation-webui
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packages/llm/text-generation-webui/docker-entrypoint.sh
+++ b/packages/llm/text-generation-webui/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd /opt/text-generation-webui && python3 server.py --model-dir=/data/models/text-generation-webui --listen --verbose "$@"

--- a/packages/tvm/Dockerfile
+++ b/packages/tvm/Dockerfile
@@ -73,4 +73,4 @@ RUN pip3 show tvm && python3 -c 'import tvm'
 
 ENV TVM_HOME=/opt/tvm
 
-ln -s /opt/mlc-llm/3rdparty/tvm/3rdparty /usr/local/lib/python3.8/dist-packages/tvm/3rdparty
+RUN ln -s /opt/mlc-llm/3rdparty/tvm/3rdparty /usr/local/lib/python3.8/dist-packages/tvm/3rdparty


### PR DESCRIPTION
I want to add extra arg `--api` to the `sd-webui`, then I found the current Dockerfile not easy to make.
With the entry point style, I could add extra args by `./run.sh $(./autotag stable-diffusion-webui) --api` which convenient for people.

I also checked other images and made the same change.

In addition, I set `WORKDIR` to the app folder.

What do you think?