### PR TITLE
Add the `openai-triton` and `nodejs` packages

### DIFF
--- a/packages/nodejs/Dockerfile
+++ b/packages/nodejs/Dockerfile
@@ -14,7 +14,7 @@ ARG NODE_MAJOR=20
 RUN set -ex \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \

--- a/packages/nodejs/Dockerfile
+++ b/packages/nodejs/Dockerfile
@@ -1,0 +1,28 @@
+#---
+# name: nodejs
+# group: build
+# depends: [build-essential]
+# test: test.sh
+# notes: installs `nodejs`, `npm`
+#---
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+ENV NODE_MAJOR=20
+
+# install prerequisites
+RUN set -ex \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+ENV PATH=/usr/bin/node:$PATH
+
+RUN set -ex \
+    && node --version \
+    && npm --version

--- a/packages/nodejs/Dockerfile
+++ b/packages/nodejs/Dockerfile
@@ -9,9 +9,8 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
-ENV NODE_MAJOR=20
+ARG NODE_MAJOR=20
 
-# install prerequisites
 RUN set -ex \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/packages/nodejs/test.sh
+++ b/packages/nodejs/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+echo "testing nodejs..."
+
+node --version
+
+echo "nodejs OK"
+
+echo "testing npm..."
+
+npm --version
+
+echo "npm OK"

--- a/packages/openai-triton/Dockerfile
+++ b/packages/openai-triton/Dockerfile
@@ -1,0 +1,38 @@
+#---
+# name: openai-triton
+# group: openai
+# depends: [build-essential, cmake, python, pytorch]
+# requires: '>=35'
+# test: test.py
+# notes: The openai-triton wheel that's built is saved in the container under /opt. Based on https://cloud.tencent.com/developer/article/2317398, https://zhuanlan.zhihu.com/p/681714973, https://zhuanlan.zhihu.com/p/673525339
+#---
+
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+ARG TRITON_DIR="/opt/triton" \
+    TRITON_PTXAS_PATH="$CUDA_TOOLKIT_ROOT_DIR/bin/ptxas" \
+    TRITON_CUOBJDUMP_PATH="$CUDA_TOOLKIT_ROOT_DIR/bin/cuobjdump" \
+    TRITON_NVDISASM_PATH="$CUDA_TOOLKIT_ROOT_DIR/bin/nvdisasm"
+
+ADD https://api.github.com/repos/openai/AutoAWQ/git/refs/heads/main /tmp/triton_version.json
+
+# Install triton
+# https://github.com/openai/triton
+# Note: We need to install pybind11[global] as global
+RUN set -ex \
+    # && pip3 install --no-cache-dir --verbose ninja pybind11[global] \
+    && git clone --depth=1 https://github.com/openai/triton $TRITON_DIR \
+    && git -C "$TRITON_DIR/third_party" submodule update --init nvidia \
+    && sed 's|LLVMAMDGPUCodeGen||g' -i $TRITON_DIR/CMakeLists.txt \
+    && sed 's|LLVMAMDGPUAsmParser||g' -i $TRITON_DIR/CMakeLists.txt \
+    && sed 's|-Werror|-Wno-error|g' -i $TRITON_DIR/CMakeLists.txt \
+    && pip3 wheel --wheel-dir=/opt --no-deps --verbose $TRITON_DIR/python \
+    && pip3 install --no-cache-dir --verbose /opt/triton*.whl \
+    && rm -rf $TRITON_DIR
+
+# test triton
+RUN set -ex \
+    && pip3 show triton \
+    && python3 -c 'import triton'

--- a/packages/openai-triton/Dockerfile
+++ b/packages/openai-triton/Dockerfile
@@ -12,9 +12,9 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG TRITON_DIR="/opt/triton" \
-    TRITON_PTXAS_PATH="$CUDA_TOOLKIT_ROOT_DIR/bin/ptxas" \
-    TRITON_CUOBJDUMP_PATH="$CUDA_TOOLKIT_ROOT_DIR/bin/cuobjdump" \
-    TRITON_NVDISASM_PATH="$CUDA_TOOLKIT_ROOT_DIR/bin/nvdisasm"
+    TRITON_PTXAS_PATH="$CUDA_HOME/bin/ptxas" \
+    TRITON_CUOBJDUMP_PATH="$CUDA_HOME/bin/cuobjdump" \
+    TRITON_NVDISASM_PATH="$CUDA_HOME/bin/nvdisasm"
 
 ADD https://api.github.com/repos/openai/AutoAWQ/git/refs/heads/main /tmp/triton_version.json
 

--- a/packages/openai-triton/Dockerfile
+++ b/packages/openai-triton/Dockerfile
@@ -20,9 +20,7 @@ ADD https://api.github.com/repos/openai/AutoAWQ/git/refs/heads/main /tmp/triton_
 
 # Install triton
 # https://github.com/openai/triton
-# Note: We need to install pybind11[global] as global
 RUN set -ex \
-    # && pip3 install --no-cache-dir --verbose ninja pybind11[global] \
     && git clone --depth=1 https://github.com/openai/triton $TRITON_DIR \
     && git -C "$TRITON_DIR/third_party" submodule update --init nvidia \
     && sed 's|LLVMAMDGPUCodeGen||g' -i $TRITON_DIR/CMakeLists.txt \

--- a/packages/openai-triton/Dockerfile
+++ b/packages/openai-triton/Dockerfile
@@ -16,7 +16,7 @@ ARG TRITON_DIR="/opt/triton" \
     TRITON_CUOBJDUMP_PATH="$CUDA_HOME/bin/cuobjdump" \
     TRITON_NVDISASM_PATH="$CUDA_HOME/bin/nvdisasm"
 
-ADD https://api.github.com/repos/openai/AutoAWQ/git/refs/heads/main /tmp/triton_version.json
+ADD https://api.github.com/repos/openai/triton/git/refs/heads/main /tmp/triton_version.json
 
 # Install triton
 # https://github.com/openai/triton

--- a/packages/openai-triton/Dockerfile
+++ b/packages/openai-triton/Dockerfile
@@ -11,8 +11,9 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
-ARG TRITON_DIR="/opt/triton" \
-    TRITON_PTXAS_PATH="$CUDA_HOME/bin/ptxas" \
+ARG TRITON_DIR="/opt/triton"
+
+ENV TRITON_PTXAS_PATH="$CUDA_HOME/bin/ptxas" \
     TRITON_CUOBJDUMP_PATH="$CUDA_HOME/bin/cuobjdump" \
     TRITON_NVDISASM_PATH="$CUDA_HOME/bin/nvdisasm"
 

--- a/packages/openai-triton/test.py
+++ b/packages/openai-triton/test.py
@@ -1,0 +1,20 @@
+import torch
+import triton
+import triton.language as tl
+
+@triton.jit
+def kernel(X, stride_xm, stride_xn, BLOCK: tl.constexpr) -> None:
+    pass
+
+print("testing triton...")
+
+print('triton version: ' + str(triton.__version__))
+
+print("testing triton kernel...")
+
+X = torch.randn(1, device="cuda")
+pgm = kernel[(1, )](X, 1, 1, BLOCK=1024)
+
+print(pgm)
+
+print("triton OK...")


### PR DESCRIPTION
Hi @dusty-nv 👋 

Below I'm proposing to merge this PR to introduce new packages into the Jetson family:

### `nodejs`
https://nodejs.org
- well known `nodejs` as a standalone package with option to install based on `NODE_MAJOR` env variable 

### `openai-triton`
https://openai.com/research/triton
- open-source Python-like programming language which enables researchers with no `CUDA` experience to write highly efficient GPU code