### PR TITLE
#409 - Fixed location of Deepstream Python Examples

### DIFF
--- a/packages/deepstream/Dockerfile
+++ b/packages/deepstream/Dockerfile
@@ -62,7 +62,7 @@ ARG PYDS_VERSION
 ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
 
-RUN cd /opt/nvidia/deepstream/deepstream && \
+RUN cd /opt/nvidia/deepstream/deepstream/sources && \
     git clone --branch ${PYDS_VERSION} --recursive --depth=1 https://github.com/NVIDIA-AI-IOT/deepstream_python_apps && \
     cd deepstream_python_apps/bindings && \
     mkdir build && \


### PR DESCRIPTION
The directories referenced in the config files for the Deepstream Python examples expect the repo to be one level deeper in the Deepstream file tree, this moves the location that the terminal is placed at when cloning the repository to the `/opt/nvidia/deepstream/deepstream/sources` folder to satisfy this expectation

Addresses Issue #409