### PR TITLE
Streamlined `openai-triton` container 🍒

### DIFF
--- a/packages/openai-triton/Dockerfile.builder
+++ b/packages/openai-triton/Dockerfile.builder
@@ -1,5 +1,5 @@
 #---
-# name: openai-triton
+# name: openai-triton:builder
 # group: ml
 # depends: [build-essential, cmake, python, pytorch]
 # config: config.py
@@ -7,19 +7,27 @@
 # test: test.py
 # notes: The OpenAI `triton` (https://github.com/openai/triton) wheel that's built is saved in the container under `/opt`. Based on https://cloud.tencent.com/developer/article/2317398, https://zhuanlan.zhihu.com/p/681714973, https://zhuanlan.zhihu.com/p/673525339
 #---
+
 ARG BASE_IMAGE
-ARG BUILD_IMAGE
-
-FROM ${BUILD_IMAGE} as builder
-FROM ${BASE_IMAGE} as runtime
-
-COPY --from=builder /opt/triton*.whl /opt/
+FROM ${BASE_IMAGE}
 
 ENV TRITON_PTXAS_PATH="$CUDA_HOME/bin/ptxas" \
     TRITON_CUOBJDUMP_PATH="$CUDA_HOME/bin/cuobjdump" \
     TRITON_NVDISASM_PATH="$CUDA_HOME/bin/nvdisasm"
 
+ADD https://api.github.com/repos/openai/triton/git/refs/heads/main /tmp/triton_version.json
+
 RUN set -ex \
+    && git clone --depth=1 https://github.com/openai/triton /opt/triton \
+    && git -C /opt/triton/third_party submodule update --init nvidia \
+    && sed -i \
+        -e 's|LLVMAMDGPUCodeGen||g' \
+        -e 's|LLVMAMDGPUAsmParser||g' \
+        -e 's|-Werror|-Wno-error|g' \
+        /opt/triton/CMakeLists.txt \
+    && pip3 wheel --wheel-dir=/opt --no-deps --verbose /opt/triton/python \
+    && rm -rf /opt/triton \
+    \
     && pip3 install --no-cache-dir --verbose /opt/triton*.whl \
     \
     && pip3 show triton \

--- a/packages/openai-triton/config.py
+++ b/packages/openai-triton/config.py
@@ -1,0 +1,14 @@
+from jetson_containers import find_container
+
+
+builder = package.copy()
+runtime = package.copy()
+
+builder['name'] = 'openai-triton:builder'
+builder['dockerfile'] = 'Dockerfile.builder'
+
+runtime['build_args'] = {
+    'BUILD_IMAGE': find_container(builder['name']),
+}
+
+package = [builder, runtime]


### PR DESCRIPTION
Hi @dusty-nv! 👋

It's a 🍒 cherry-picked PR from https://github.com/dusty-nv/jetson-containers/pull/414 to introduce improvements only for `openai-triton` container:

- Add `config.py`
- Add `Dockerfile.builder` for a separate `pip` wheel build
- Reduced number of layers
- Fixed formatting