### PR TITLE
Streamlined `text-generation-webui` container 🍒

### DIFF
--- a/packages/llm/text-generation-webui/Dockerfile
+++ b/packages/llm/text-generation-webui/Dockerfile
@@ -2,7 +2,7 @@
 # name: text-generation-webui
 # group: llm
 # config: config.py
-# depends: [transformers, bitsandbytes, auto_gptq, gptq-for-llama, exllama:v1, exllama:v2, llama_cpp:gguf, openai-triton]
+# depends: [transformers, auto_gptq, gptq-for-llama, exllama:v1, exllama:v2, llama_cpp:gguf]
 # requires: '>=34.1.0'
 # docs: docs.md
 #---

--- a/packages/llm/text-generation-webui/Dockerfile
+++ b/packages/llm/text-generation-webui/Dockerfile
@@ -2,87 +2,79 @@
 # name: text-generation-webui
 # group: llm
 # config: config.py
-# depends: [transformers, auto_gptq, gptq-for-llama, exllama:v1, exllama:v2, llama_cpp:gguf]
+# depends: [transformers, bitsandbytes, auto_gptq, gptq-for-llama, exllama:v1, exllama:v2, llama_cpp:gguf, openai-triton]
 # requires: '>=34.1.0'
 # docs: docs.md
 #---
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-WORKDIR /opt
+ARG OOBABOOGA_REF \
+    OOBABOOGA_SHA \
+    OOBABOOGA_ROOT_DIR="/opt/text-generation-webui" \
+    OOBABOOGA_MODEL_DIR="/data/models/text-generation-webui" \
+    FLASH_ATTENTION_BRANCH="v2.5.6" \
+    LD_PRELOAD_LIBS=""
 
-ARG OOBABOOGA_REF
-ARG OOBABOOGA_SHA
-
+# Check GitHub API for version information
 ADD https://api.github.com/repos/oobabooga/text-generation-webui/git/${OOBABOOGA_REF} /tmp/oobabooga_version.json
 
-RUN git clone https://github.com/oobabooga/text-generation-webui && \
-    cd text-generation-webui && \
-    git checkout ${OOBABOOGA_SHA}
+# Copy all patch files
+COPY *.diff /tmp/
 
-RUN cd text-generation-webui && \
-    #sed 's|^numpy.*|numpy|g' -i requirements.txt && \
-    #sed 's|^accelerate.*|accelerate|g' -i requirements.txt && \
-    sed 's|^bitsandbytes.*|#bitsandbytes|g' -i requirements.txt && \
-    #sed 's|^fastapi.*|fastapi|g' -i requirements.txt && \
-    #sed 's|^safetensors.*|safetensors|g' -i requirements.txt && \
-    sed 's|^llama-cpp-python.*|llama-cpp-python|g' -i requirements.txt && \
-    sed 's|^exllamav2.*|exllamav2|g' -i requirements.txt && \
-    sed 's|^autoawq.*||g' -i requirements.txt && \
-    #sed 's|^transformers.*|transformers|g' -i requirements.txt && \
-    #sed 's|^optimum.*|optimum|g' -i requirements.txt && \
-    #sed 's|^pydantic.*|pydantic|g' -i requirements.txt && \
-    #sed 's|^aiofiles.*|aiofiles|g' -i requirements.txt && \
-    #sed 's|^gradio.*|gradio|g' -i requirements.txt && \
-    #sed 's|^gradio_client.*|gradio_client|g' -i requirements.txt && \
-    #sed 's|^peft.*|peft|g' -i requirements.txt && \
-    sed 's|^git+https://github.com/oobabooga/torch-grammar.git||g' -i requirements.txt && \
-    sed 's|^git+https://github.com/huggingface/transformers.*|transformers|g' -i requirements.txt && \
-    sed 's|^git+https://github.com/huggingface/peft|#git+https://github.com/huggingface/peft|g' -i requirements.txt && \
-    sed 's|^https://github.com/PanQiWei/AutoGPTQ|#https://github.com/PanQiWei/AutoGPTQ|g' -i requirements.txt && \
-    sed 's|^https://github.com/jllllll/ctransformers-cuBLAS-wheels.*|#https://github.com/jllllll/ctransformers-cuBLAS-wheels|g' -i requirements.txt && \
-    cat requirements.txt
-    
-RUN pip3 install --no-cache-dir --verbose -r text-generation-webui/requirements.txt
+# Install text-generation-webui
+RUN set -ex \
+    && git clone https://github.com/oobabooga/text-generation-webui "$OOBABOOGA_ROOT_DIR" \
+    && git -C "$OOBABOOGA_ROOT_DIR" checkout "$OOBABOOGA_SHA" \
+    \
+    # Fix text-generation-webui requirements \
+    && sed -i \
+        -e 's|^bitsandbytes.*|#bitsandbytes|g' \
+        -e 's|^llama-cpp-python.*|llama-cpp-python|g' \
+        -e 's|^exllamav2.*|exllamav2|g' \
+        -e 's|^autoawq.*||g' \
+        -e 's|^transformers.*|transformers|g' \
+        -e 's|^https://github.com/jllllll/ctransformers-cuBLAS-wheels.*|#https://github.com/jllllll/ctransformers-cuBLAS-wheels|g' \
+        "$OOBABOOGA_ROOT_DIR/requirements.txt" \
+    \
+    # Fix https://github.com/oobabooga/text-generation-webui/issues/4644 \
+    && sed 's|to(self\.projector_device)|to(self\.projector_device,dtype=self\.projector_dtype)|' -i "$OOBABOOGA_ROOT_DIR/extensions/multimodal/pipelines/llava/llava.py" \
+    # Fix: cannot uninstall 'blinker': It is a distutils installed project \
+    && pip3 install --no-cache-dir --ignore-installed blinker \
+    # Add text-generation-webui required dependencies \
+    && echo "git+https://github.com/oobabooga/torch-grammar.git@main" >> "$OOBABOOGA_ROOT_DIR/requirements.txt" \
+    && echo "git+https://github.com/UKPLab/sentence-transformers.git@master" >> "$OOBABOOGA_ROOT_DIR/requirements.txt" \
+    \
+    # Create a symbolic link from /opt/GPTQ-for-LLaMa/*.py to oobabooga root dir \
+    # TODO: Grab the /opt/GPTQ-for-LLaMa/*.py files from `builder` image \
+    && ln -s /opt/GPTQ-for-LLaMa/*.py "$OOBABOOGA_ROOT_DIR" \
+    \
+    # Install text-generation-webui \
+    && pip3 install --no-cache-dir --verbose -r "$OOBABOOGA_ROOT_DIR/requirements.txt" \
+    # Install text-generation-webui extensions \
+    && cd "$OOBABOOGA_ROOT_DIR" \
+    && python -c "from one_click import install_extensions_requirements; install_extensions_requirements()" \
+    \
+    # Install flash-attention \
+    && git clone --depth=1 --branch="$FLASH_ATTENTION_BRANCH" https://github.com/Dao-AILab/flash-attention /opt/flash-attention \
+    && git -C /opt/flash-attention apply /tmp/flash-attn.diff \
+    && export FLASH_ATTENTION_FORCE_BUILD=1 \
+        FLASH_ATTENTION_FORCE_CXX11_ABI=0 \
+        FLASH_ATTENTION_SKIP_CUDA_BUILD=0 \
+    && cd /opt/flash-attention/ \
+    && python3 setup.py install \
+    \
+    # Cleanup \
+    && rm -rf \
+        /opt/flash-attention \
+        /var/lib/apt/lists/* \
+        "$OOBABOOGA_ROOT_DIR/api-examples" \
+        "$OOBABOOGA_ROOT_DIR/docker" \
+        "$OOBABOOGA_ROOT_DIR/docs" \
+    && apt-get clean
 
-#RUN cd text-generation-webui && \
-#    pip3 freeze > /tmp/constraints.txt && \
-#    pip3 install --no-cache-dir --verbose -r requirements.txt --constraint /tmp/constraints.txt && \
-#    rm /tmp/constraints.txt
-    
-# https://github.com/oobabooga/text-generation-webui/issues/4644
-RUN sed 's|to(self\.projector_device)|to(self\.projector_device,dtype=self\.projector_dtype)|' -i /opt/text-generation-webui/extensions/multimodal/pipelines/llava/llava.py && \
-    cat /opt/text-generation-webui/extensions/multimodal/pipelines/llava/llava.py | grep 'projector_dtype'
-    
-RUN cd text-generation-webui && \
-    sed 's|@functools.cache|@functools.lru_cache\(maxsize=None\)|' -i modules/chat.py && \
-    sed 's|@functools.cache|@functools.lru_cache\(maxsize=None\)|' -i modules/loaders.py && \
-    sed 's|@functools.cache|@functools.lru_cache\(maxsize=None\)|' -i modules/presets.py
+COPY settings.yaml ${OOBABOOGA_ROOT_DIR}
 
-RUN cp /opt/GPTQ-for-LLaMa/*.py /opt/text-generation-webui
+ENV LD_PRELOAD="${LD_PRELOAD}:${LD_PRELOAD_LIBS}"
 
-# https://github.com/oobabooga/text-generation-webui/issues/3042#issuecomment-1626160643
-#RUN pip3 install --no-cache-dir --verbose 'gradio>=3.36.1'
-RUN pip3 install --no-cache-dir --ignore-installed blinker  # cannot uninstall 'blinker': It is a distutils installed project
-RUN pip3 install --no-cache-dir --verbose -r text-generation-webui/extensions/openai/requirements.txt
-
-RUN if [ -f text-generation-webui/extensions/api/requirements.txt ] ; then \
-	 pip3 install --no-cache-dir --verbose -r text-generation-webui/extensions/api/requirements.txt ; \
-    fi
-
-RUN git clone --depth=1 https://github.com/oobabooga/torch-grammar && \
-    cd torch-grammar && \
-    sed 's|"\^3.9"|"^3.8"|' -i pyproject.toml && \
-    cat pyproject.toml && \
-    pip3 wheel --wheel-dir=dist --no-deps --verbose . && \
-    cp dist/torch_grammar*.whl /opt && \
-    pip3 install --no-cache-dir --verbose /opt/torch_grammar*.whl
-
-ARG LD_PRELOAD_LIBS=""    
-ENV LD_PRELOAD=${LD_PRELOAD}:${LD_PRELOAD_LIBS}
-
-COPY settings.json text-generation-webui/
-
-WORKDIR /
-
-CMD /bin/bash -c "cd /opt/text-generation-webui && python3 server.py --model-dir=/data/models/text-generation-webui --listen --verbose"
+CMD ["/bin/bash", "-c", "cd $OOBABOOGA_ROOT_DIR && python3", "server.py", "--model-dir=$OOBABOOGA_MODEL_DIR", "--listen", "--verbose", "--triton"]

--- a/packages/llm/text-generation-webui/flash-attn.diff
+++ b/packages/llm/text-generation-webui/flash-attn.diff
@@ -1,0 +1,70 @@
+diff --git a/setup.py b/setup.py
+index 75c92cb..5971477 100644
+--- a/setup.py
++++ b/setup.py
+@@ -45,20 +45,38 @@ SKIP_CUDA_BUILD = os.getenv("FLASH_ATTENTION_SKIP_CUDA_BUILD", "FALSE") == "TRUE
+ # For CI, we want the option to build with C++11 ABI since the nvcr images use C++11 ABI
+ FORCE_CXX11_ABI = os.getenv("FLASH_ATTENTION_FORCE_CXX11_ABI", "FALSE") == "TRUE"
+ 
++def get_system() -> str:
++    """
++    Returns the system name as used in wheel filenames.
++    """
++    if platform.system() == "Windows":
++        return "win"
++    elif platform.system() == "Darwin":
++        mac_version = ".".join(platform.mac_ver()[0].split(".")[:1])
++        return f"macos_{mac_version}"
++    elif platform.system() == "Linux":
++        return "linux"
++    else:
++        raise ValueError("Unsupported system: {}".format(platform.system()))
+ 
+-def get_platform():
++
++def get_arch():
+     """
+-    Returns the platform name as used in wheel filenames.
++    Returns the system name as used in wheel filenames.
+     """
+-    if sys.platform.startswith("linux"):
+-        return "linux_x86_64"
+-    elif sys.platform == "darwin":
+-        mac_version = ".".join(platform.mac_ver()[0].split(".")[:2])
+-        return f"macosx_{mac_version}_x86_64"
+-    elif sys.platform == "win32":
+-        return "win_amd64"
++    if platform.machine() == "x86_64":
++        return "x86_64"
++    elif platform.machine() == "arm64" or platform.machine() == "aarch64":
++        return "aarch64"
+     else:
+-        raise ValueError("Unsupported platform: {}".format(sys.platform))
++        raise ValueError("Unsupported arch: {}".format(platform.machine()))
++
++
++def get_platform() -> str:
++    """
++    Returns the platform name as used in wheel filenames.
++    """
++    return f"{get_system()}_{get_arch()}"
+ 
+ 
+ def get_cuda_bare_metal_version(cuda_dir):
+@@ -115,14 +133,11 @@ if not SKIP_CUDA_BUILD:
+                 "FlashAttention is only supported on CUDA 11.6 and above.  "
+                 "Note: make sure nvcc has a supported version by running nvcc -V."
+             )
+-    # cc_flag.append("-gencode")
+-    # cc_flag.append("arch=compute_75,code=sm_75")
+-    cc_flag.append("-gencode")
+-    cc_flag.append("arch=compute_80,code=sm_80")
++
+     if CUDA_HOME is not None:
+         if bare_metal_version >= Version("11.8"):
+             cc_flag.append("-gencode")
+-            cc_flag.append("arch=compute_90,code=sm_90")
++            cc_flag.append("arch=compute_87,code=sm_87")
+ 
+     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
+     # torch._C._GLIBCXX_USE_CXX11_ABI

--- a/packages/llm/text-generation-webui/settings.json
+++ b/packages/llm/text-generation-webui/settings.json
@@ -1,4 +1,0 @@
-{
-  "multimodal-vision_bits": 16,
-  "multimodal-projector_bits": 16
-}

--- a/packages/llm/text-generation-webui/settings.yaml
+++ b/packages/llm/text-generation-webui/settings.yaml
@@ -1,0 +1,2 @@
+multimodal-vision_bits: 16
+multimodal-projector_bits: 16


### PR DESCRIPTION
Hi @dusty-nv 👋

It's a 🍒 cherry-picked PR from https://github.com/dusty-nv/jetson-containers/pull/414 to introduce improvements only for `text-generation-webui` container:

- Reduced number of layers
- Fixed formatting
- Refactor `torch-grammar` installation commands
- Add `sentence-transformers` and `flash-attention` with `git` patch (`v1` & `v2` supported)
- Create symbolic links instead of duplicating files from `GPTQ-for-LLaMa` container. @dusty-nv do we still need `GPTQ-for-LLaMa` as a dependency when we use `auto_gptq` in `text-generation-webui` container?
- Introduced a new way of automatic `text-generation-webui` extensions installation using native `one_click.install_extensions_requirements` script
- migration from `settings.json` to `settings.yaml` - when user saves `text-generation-webui` UI Settings to drive, they are saved to `settings.yaml`, not `settings.json`