### PR TITLE
Build ONNX Runtime shared lib

### DIFF
--- a/packages/onnxruntime/Dockerfile.builder
+++ b/packages/onnxruntime/Dockerfile.builder
@@ -23,7 +23,7 @@ RUN pip3 uninstall -y onnxruntime && \
     git checkout ${ONNXRUNTIME_VERSION} && \
     git submodule update --init --recursive && \
     sed -i 's|archive/3.4/eigen-3.4.zip;ee201b07085203ea7bd8eb97cbcb31b07cfa3efb|archive/3.4.0/eigen-3.4.0.zip;ef24286b7ece8737c99fa831b02941843546c081|' cmake/deps.txt || echo "cmake/deps.txt not found" && \
-    ./build.sh --config Release --update --parallel --build --build_wheel \
+    ./build.sh --config Release --update --parallel --build --build_wheel --build_shared_lib \
         --skip_tests --skip_submodule_sync ${ONNXRUNTIME_FLAGS} \
         --cmake_extra_defines CMAKE_CXX_FLAGS="-Wno-unused-variable -I/usr/local/cuda/include" CMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" onnxruntime_BUILD_UNIT_TESTS=OFF \
         --cuda_home /usr/local/cuda --cudnn_home /usr/lib/$(uname -m)-linux-gnu \


### PR DESCRIPTION
Many ORT applications, specially C/C++ ones will link against libonnxruntime.so, which isn't built unless the --build_shared_lib option is passed to the build script.