### PR TITLE
fix(ctranslate2): Add missing cuda & cudnn deps

### DIFF
--- a/packages/ctranslate2/Dockerfile
+++ b/packages/ctranslate2/Dockerfile
@@ -1,7 +1,7 @@
 #---
 # name: ctranslate2
 # group: transformer
-# depends: [cmake]
+# depends: [cmake, cuda, cudnn]
 # requires: '>=34.1.0'
 # docs: docs.md
 #---


### PR DESCRIPTION
Hi,

Just adding the missing `cuda` & `cudnn` deps which I found missing and breaking the `ctranslate2` build.

Best,
M