### PR TITLE
fixed not loading audiocraft examples, and added voicecraft dockerfile

### DIFF
--- a/packages/audio/audiocraft/Dockerfile
+++ b/packages/audio/audiocraft/Dockerfile
@@ -10,6 +10,20 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /opt
 
+# install https://github.com/libsndfile/libsndfile from source to get mp3 support for jupyter examples
+RUN git clone https://github.com/libsndfile/libsndfile.git && \
+    cd libsndfile && \
+    apt-get update && \
+    apt install -y autoconf autogen automake build-essential libasound2-dev libflac-dev libogg-dev libtool libvorbis-dev libopus-dev libmp3lame-dev  libmpg123-dev pkg-config python2 && \
+    autoreconf -vif && \
+    ./configure --enable-werror && \
+    make -j$(nproc) && \
+    make check && \
+    make install && \
+    ldconfig && \
+    rm -rf /var/lib/apt/lists/*  && \
+    apt-get clean
+
 #RUN pip3 install matplotlib pycocotools tqdm
 RUN pip3 install torchmetrics
 
@@ -22,9 +36,8 @@ RUN git clone https://github.com/facebookresearch/audiocraft/ && \
     sed 's|^xformers.*||' -i requirements.txt && \
     sed 's|^protobuf.*||' -i requirements.txt && \
     cat requirements.txt && \
-    pip3 install .
+    pip3 install -e .
 
-RUN pip3 install --verbose /opt/torch*.whl
 
 RUN python3 -c 'import torch; print(f"PyTorch version: {torch.__version__}"); print(f"CUDA available:  {torch.cuda.is_available()}"); print(f"cuDNN version:   {torch.backends.cudnn.version()}"); print(f"torch.distributed:   {torch.distributed.is_available()}"); print(torch.__config__.show());'
 RUN python3 -c 'import torch; assert(torch.cuda.is_available()); assert(torch.distributed.is_available())'

--- a/packages/audio/faster-whisper/Dockerfile
+++ b/packages/audio/faster-whisper/Dockerfile
@@ -15,6 +15,7 @@ RUN git clone https://github.com/guillaumekln/faster-whisper && \
     # sed 's|^onnxruntime.*||' -i requirements.txt && \
     sed 's|^ctranslate2.*||' -i requirements.txt && \
     sed 's|^huggingface_hub.*||' -i requirements.txt && \
+    sed 's|^tokenizers.*|tokenizers|' -i requirements.txt && \
     cat requirements.txt && \
     pip3 install --no-cache-dir --verbose -r requirements.txt && \
     python3 setup.py bdist_wheel

--- a/packages/audio/voicecraft/Dockerfile
+++ b/packages/audio/voicecraft/Dockerfile
@@ -1,0 +1,39 @@
+#---
+# name: voicecraft
+# group: audio
+# depends: [pytorch, torchvision, torchaudio, huggingface_hub, transformers, xformers, audiocraft,whisperx]
+#---
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+
+WORKDIR /opt
+
+# Install dependencies"
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends espeak-ng && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get install -y espeak espeak-data libespeak1 libespeak-dev && \
+    apt-get install -y festival* && \
+    apt-get install -y build-essential && \
+    apt-get install -y flac libasound2-dev libsndfile1-dev vorbis-tools && \
+    apt-get install -y libxml2-dev libxslt-dev zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*  && \
+    apt-get clean
+
+RUN pip3 install phonemizer  && \
+    pip3 install torchmetrics
+
+# Clone the repository:
+RUN git clone https://github.com/jasonppy/VoiceCraft.git && \
+    cd VoiceCraft && \
+    sed 's|^whisperx.*||' -i gradio_requirements.txt && \
+    sed 's|^huggingface_hub.*||' -i gradio_requirements.txt && \
+    cat gradio_requirements.txt && \
+    pip install -r gradio_requirements.txt
+
+WORKDIR /opt/VoiceCraft/
+
+# ENTRYPOINT [ “python3”, “gradio_app.py”, "--server_name", "0.0.0.0" ]
+
+CMD [ "python3", "./gradio_app.py" , "--server_name" , "0.0.0.0" ]


### PR DESCRIPTION
Fixed [ "Failed to load audio" RuntimeError.](https://www.jetson-ai-lab.com/tutorial_audiocraft.html) - it was probably combination of two things:

1. old libsndfile that [doesn't play mp3 ](https://github.com/libsndfile/libsndfile/issues/258)
2. didn't use the [e flag](https://www.youtube.com/watch?v=9xMpJyytn3M) 
- normally `pip install . ` installs into` /dist-packages/<package>`
- e enables editable mode where it only symlinks it into  `/dist-packages/` and audiocraft repo uses it with relative paths to get assets and other scripts/programs, that's where it breaks loading of files

Added [VoiceCraft](https://github.com/jasonppy/VoiceCraft) container 

1. It is SOTA Voice editing/ TTS
2. In the repo they use conda, but after checking the issues it is not really needed:
- the packages they use with conda are for alignment which whisperx does too

I put `gradio_app.py` in the CMD instruction, since otherwise the jupyter from previous layer/package would run, it runs `0.0.0.0:7860 `at start. 


