### PR TITLE
add JP6 GA to l4t_version.py

### DIFF
--- a/jetson_containers/l4t_version.py
+++ b/jetson_containers/l4t_version.py
@@ -84,6 +84,7 @@ def get_jetpack_version(l4t_version=get_l4t_version(), default='5.1'):
         
     NVIDIA_JETPACK = {
         # -------- JP6 --------
+        "36.3.0": "6.0 GA",
         "36.2.0": "6.0 DP",
         "36.0.0": "6.0 EA",
         


### PR DESCRIPTION
autotag was showing 5.1 as the jetpack version on JP6 GA system. 