### PR TITLE
Add rosbag2_storage_mcap to ROS image

### DIFF
--- a/packages/ros/ros2_build.sh
+++ b/packages/ros/ros2_build.sh
@@ -95,6 +95,7 @@ rosinstall_generator --deps --rosdistro ${ROS_DISTRO} ${ROS_PACKAGE} \
 	image_transport \
 	compressed_image_transport \
 	compressed_depth_image_transport \
+ 	rosbag2_storage_mcap \
 > ros2.${ROS_DISTRO}.${ROS_PACKAGE}.rosinstall
 cat ros2.${ROS_DISTRO}.${ROS_PACKAGE}.rosinstall
 vcs import src < ros2.${ROS_DISTRO}.${ROS_PACKAGE}.rosinstall


### PR DESCRIPTION
rosbag2_storage_mcap is not installed in the humble image (it might be for Iron and above that because it is the default)