### PR TITLE
Support `jtop`

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -48,3 +48,11 @@ This is the order in which [`autotag`](/autotag) searches for container images:
 3. Build it from source (it'll ask for confirmation first)
 
 When searching for images, it knows to find containers that are compatible with your version of JetPack-L4T.  For example, if you're on JetPack 4.6.x (L4T R32.7.x), you can run images that were built for other versions of JetPack 4.6.  Or if you're on JetPack 5.1 (L4T R35), you can run images built for other versions of JetPack 5.1 (and likewise for JetPack 6.0 and newer)
+
+## `jtop`
+
+If you have installed [**jetson-stats**](https://github.com/rbonghi/jetson_stats) (or `jtop`) on your host, now a container with jetson-stats (`jtop`) installed can work inside the container by communicating with host server through a socket `/run/jtop.sock` (with `-v /run/jtop.sock:/run/jtop.sock` argument for `docker run`).
+
+Check the [official documentation](https://rnext.it/jetson_stats/docker.html) for the detail.
+
+Make sure you install the same version of jetson-stats (`jtop`) both on your host and in the container.

--- a/run.sh
+++ b/run.sh
@@ -39,6 +39,14 @@ if [ -n "$DISPLAY" ]; then
 	DISPLAY_DEVICE="-e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix -v $XAUTH:$XAUTH -e XAUTHORITY=$XAUTH"
 fi
 
+# check for jtop
+JTOP_SOCKET=""
+JTOP_SOCKET_FILE="/run/jtop.sock"
+
+if [ -f "$JTOP_SOCKET_FILE" ]; then
+	JTOP_SOCKET="-v /run/jtop.sock:/run/jtop.sock"
+fi
+
 # extra flags
 EXTRA_FLAGS=""
 
@@ -75,7 +83,7 @@ if [ $ARCH = "aarch64" ]; then
 		--volume $ROOT/data:/data \
 		--device /dev/snd \
 		--device /dev/bus/usb \
-		$DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $EXTRA_FLAGS \
+		$DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $JTOP_SOCKET $EXTRA_FLAGS \
 		"$@"
 
 elif [ $ARCH = "x86_64" ]; then
@@ -88,6 +96,6 @@ elif [ $ARCH = "x86_64" ]; then
 		--ulimit stack=67108864 \
 		--env NVIDIA_DRIVER_CAPABILITIES=all \
 		--volume $ROOT/data:/data \
-		$DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $EXTRA_FLAGS \
+		$DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $JTOP_SOCKET $EXTRA_FLAGS \
 		"$@"	
 fi

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ fi
 JTOP_SOCKET=""
 JTOP_SOCKET_FILE="/run/jtop.sock"
 
-if [ -f "$JTOP_SOCKET_FILE" ]; then
+if [ -S "$JTOP_SOCKET_FILE" ]; then
 	JTOP_SOCKET="-v /run/jtop.sock:/run/jtop.sock"
 fi
 


### PR DESCRIPTION
Enable jetson-stats (`jtop`) in containers by adding `-v /run/jtop.sock:/run/jtop.sock` when jetson-stats (`jtop`) is installed on the host.
Added a simple explanation in `docs/run.md` as well.

Official doc:
https://rnext.it/jetson_stats/docker.html