### PR TITLE
[WIP] Add `jupyterlab:myst` sub-package

### DIFF
--- a/packages/hardware/jupyter_clickable_image_widget/Dockerfile
+++ b/packages/hardware/jupyter_clickable_image_widget/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && \
     apt-get clean
 RUN npm install -g node-gyp
 # RUN pip3 install --no-cache-dir --verbose jupyter 'jupyterlab==4.2.0' && \
-RUN pip3 install --no-cache-dir --verbose jupyter 'jupyterlab<4' && \
-    pip3 install --no-cache-dir --verbose jupyterlab_widgets
+# RUN pip3 install --no-cache-dir --verbose jupyter 'jupyterlab<4' && \
+#     pip3 install --no-cache-dir --verbose jupyterlab_widgets
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 # For ipywidget development

--- a/packages/jupyterlab/Dockerfile
+++ b/packages/jupyterlab/Dockerfile
@@ -1,5 +1,6 @@
 #---
 # name: jupyterlab
+# alias: jupyterlab:main
 # group: core
 # depends: [python, numpy, rust]
 # docs: docs.md

--- a/packages/jupyterlab/Dockerfile
+++ b/packages/jupyterlab/Dockerfile
@@ -16,12 +16,17 @@ SHELL ["/bin/bash", "-c"]
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /root/.bashrc
 
 # jupyterlab<4 -- ModuleNotFoundError: No module named 'notebook.auth'
-RUN pip3 install --no-cache-dir --verbose jupyter 'jupyterlab<4' && \
+RUN pip3 install --no-cache-dir --verbose jupyter 'jupyterlab==4.2.0' && \
     pip3 install --no-cache-dir --verbose jupyterlab_widgets
+
+RUN pip3 list
+RUN jupyter --version
+RUN jupyter labextension list
     
 RUN jupyter lab --version && jupyter lab --generate-config
-RUN python3 -c "from notebook.auth.security import set_password; set_password('nvidia', '/root/.jupyter/jupyter_notebook_config.json')"
+# RUN python3 -c "from notebook.auth.security import set_password; set_password('nvidia', '/root/.jupyter/jupyter_notebook_config.json')"
 
+COPY jupyter_server_config.json /root/.jupyter/
 COPY start_jupyter /
 CMD /start_jupyter && /bin/bash
 

--- a/packages/jupyterlab/Dockerfile.myst
+++ b/packages/jupyterlab/Dockerfile.myst
@@ -1,0 +1,15 @@
+# 
+# this is the jupyterlab:myst container (built on top of jupyterlab)
+# see Dockerfile & config.py for package configuration/metadata
+#
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN pip install jupyterlab_myst sympy matplotlib
+RUN pip3 list
+RUN jupyter --version
+RUN jupyter labextension list
+
+WORKDIR /opt
+RUN git clone https://github.com/executablebooks/jupyterlab-myst/
+ENV JUPYTER_ROOT=/opt/jupyterlab-myst/examples/

--- a/packages/jupyterlab/config.py
+++ b/packages/jupyterlab/config.py
@@ -1,0 +1,10 @@
+# make a samples variant of the container
+myst = package.copy()
+
+myst['name'] = 'jupyterlab:myst'
+myst['dockerfile'] = 'Dockerfile.myst'
+myst['depends'] = ['jupyterlab:main']
+
+del myst['alias']
+
+package = [package, myst]

--- a/packages/jupyterlab/jupyter_server_config.json
+++ b/packages/jupyterlab/jupyter_server_config.json
@@ -1,0 +1,5 @@
+{
+    "IdentityProvider": {
+      "hashed_password": "argon2:$argon2id$v=19$m=10240,t=10,p=8$znFkSmzDV9gxYrjJxkxq7w$GrgImZg43mqHfN5gf8tWmyiUtt4e6aX7fWxhZTnG5RE"
+    }
+}

--- a/packages/jupyterlab/start_jupyter
+++ b/packages/jupyterlab/start_jupyter
@@ -18,7 +18,7 @@ server_url="http://$(hostname -I | cut -d' ' -f1):${JUPYTER_PORT}"
 
 printf "\nStarting JupyterLab server at $server_url (password \"${JUPYTER_PASSWORD}\")\n\n"
 
-python3 -c "from notebook.auth.security import set_password; set_password(\"${JUPYTER_PASSWORD}\", '/root/.jupyter/jupyter_notebook_config.json')"
+# python3 -c "from notebook.auth.security import set_password; set_password(\"${JUPYTER_PASSWORD}\", '/root/.jupyter/jupyter_notebook_config.json')"
 
 /bin/bash -c "jupyter lab --ip 0.0.0.0 --port $JUPYTER_PORT --notebook-dir $JUPYTER_ROOT --allow-root &> $JUPYTER_LOGS" &
 

--- a/packages/rag/langchain/Dockerfile.samples
+++ b/packages/rag/langchain/Dockerfile.samples
@@ -8,6 +8,6 @@ FROM ${BASE_IMAGE}
 WORKDIR /opt/langchain
 
 COPY *.ipynb ./
-RUN sed 's|^\ \ }|    ,"notebook_dir": "/opt/langchain"\n  }|' -i /root/.jupyter/jupyter_notebook_config.json
+# RUN sed 's|^\ \ }|    ,"notebook_dir": "/opt/langchain"\n  }|' -i /root/.jupyter/jupyter_notebook_config.json
 
 WORKDIR /


### PR DESCRIPTION
Add `jupyterlab:myst` sub-package for enabling [JupyterLab MyST Extension](https://github.com/executablebooks/jupyterlab-myst).
It requires JupyterLab >= `4.0.0`.

This PR is based on the other https://github.com/dusty-nv/jetson-containers/pull/525/ ("Upgrade JupyterLab to 4.2.0").