### PR TITLE
Optimize Ollama build by enabling `-j$(proc)`

### DIFF
--- a/packages/llm/ollama/Dockerfile
+++ b/packages/llm/ollama/Dockerfile
@@ -35,6 +35,7 @@ RUN CMAKE_VERSION=${CMAKE_VERSION} GOLANG_VERSION=${GOLANG_VERSION} sh /opt/olla
 WORKDIR ollama/llm/generate
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/compat:${LD_LIBRARY_PATH} \
     CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
+RUN sed 's|-j8|-j$(nproc)|' -i gen_common.sh && \
 RUN bash gen_linux.sh
 
 WORKDIR /opt/ollama

--- a/packages/llm/ollama/Dockerfile
+++ b/packages/llm/ollama/Dockerfile
@@ -35,7 +35,7 @@ RUN CMAKE_VERSION=${CMAKE_VERSION} GOLANG_VERSION=${GOLANG_VERSION} sh /opt/olla
 WORKDIR ollama/llm/generate
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/nvidia/compat:${LD_LIBRARY_PATH} \
     CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
-RUN sed 's|-j8|-j$(nproc)|' -i gen_common.sh && \
+RUN sed 's|-j8|-j$(nproc)|' -i gen_common.sh
 RUN bash gen_linux.sh
 
 WORKDIR /opt/ollama


### PR DESCRIPTION
Ollama build process is currently hardcoded with `-j8` options.
Enabling `-j$(proc)` reduces the Ollama build time by 2 min on Jetson AGX Orin 64GB Developer Kit.