### PR TITLE
Update Holoscan package to use Debian install

### DIFF
--- a/packages/holoscan/Dockerfile
+++ b/packages/holoscan/Dockerfile
@@ -1,18 +1,24 @@
 #---
-# name: holoscan-sdk
+# name: holoscan
 # group: ml
 # requires: '>=36'
-# depends: [pytorch, cupy, tensorrt]
+# depends: [pytorch, cupy, tensorrt, ffmpeg]
 # test: [test.sh]
-# notes: https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Quickstart.html
+# notes: https://docs.nvidia.com/holoscan/sdk-user-guide/overview.html
 #---
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 WORKDIR /opt/nvidia
-# Clone Holoscan-sdk for the examples
-RUN git clone https://github.com/nvidia-holoscan/holoscan-sdk.git
-# Install the Holoscan python package
-RUN python3 -m pip install holoscan --no-cache-dir
+
+# Clone Holoscan-sdk & HoloHub for the examples
+RUN git clone https://github.com/nvidia-holoscan/holoscan-sdk.git \
+    && git clone https://github.com/nvidia-holoscan/holohub.git
+
+# Install the Holoscan Debian package
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb \
+    && dpkg -i cuda-keyring_1.1-1_all.deb \
+    && apt-get update \
+    && apt-get -y install holoscan
 
 WORKDIR /

--- a/packages/holoscan/docs.md
+++ b/packages/holoscan/docs.md
@@ -2,10 +2,11 @@
 
 This package provides containers for [Holoscan SDK](https://github.com/nvidia-holoscan/holoscan-sdk). The Holoscan SDK can be used to build streaming AI pipelines for a variety of domains, including Medical Devices, High Performance Computing at the Edge, Industrial Inspection and more.
 
-> ⚠️ Note: This package installs the Holoscan SDK python wheel, see the [support matrix](https://docs.nvidia.com/holoscan/sdk-user-guide/sdk_installation.html#not-sure-what-to-choose) to understand which Holoscan SDK features this enables.
+> ⚠️ Note: This package installs the Holoscan SDK Debian package, see the [support matrix](https://docs.nvidia.com/holoscan/sdk-user-guide/sdk_installation.html#not-sure-what-to-choose) to understand which Holoscan SDK features this enables.
 
-## To run a sample Holoscan app:
+## To run a sample Holoscan-SDK app:
 ```bash
+export PYTHONPATH=$PYTHONPATH:/opt/nvidia/holoscan/python/lib
 python3 /opt/nvidia/holoscan-sdk/examples/hello_world/python/hello_world.py
  ```
 Example output:
@@ -25,3 +26,19 @@ Hello World!
 [info] [gxf_executor.cpp:1942] Graph execution finished.
 [info] [gxf_executor.cpp:276] Destroying context
 ```
+
+## Running HoloHub Apps:
+[HoloHub](https://github.com/nvidia-holoscan/holohub/tree/main) is a central repository for the NVIDIA Holoscan AI sensor processing community to share apps and extensions.
+
+Here is an example of how to run the [endoscopy_tool_tracking](https://github.com/nvidia-holoscan/holohub/tree/main/applications/endoscopy_tool_tracking) example:
+```bash
+export HOLOHUB_BUILD_PATH=/data/holohub/endoscopy_tool_tracking
+export PYTHONPATH=$PYTHONPATH:$HOLOHUB_BUILD_PATH/python/lib:/opt/nvidia/holoscan/python/lib
+cd /opt/nvidia/holohub
+./run build endoscopy_tool_tracking --buildpath $HOLOHUB_BUILD_PATH
+cd $HOLOHUB_BUILD_PATH
+python3 /opt/nvidia/holohub/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.python --data /opt/nvidia/holohub/data/endoscopy/
+```
+
+These apps are often more complex than the examples included in the Holoscan-SDK. As such, many apps will require that you build them first with CMake, regardless of whether you are using Python or C++. Note the use of the `--buildpath` arg, this redirects the build location from the default location to the `/data` volume that is mounted by the Jetson-Containers repo. This ensures that builds will persist across Docker runs.
+

--- a/packages/holoscan/test.sh
+++ b/packages/holoscan/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo 'testing Holoscan...'
-
+export PYTHONPATH=$PYTHONPATH:/opt/nvidia/holoscan/python/lib
 python3 /opt/nvidia/holoscan-sdk/examples/hello_world/python/hello_world.py
 
 echo 'Holoscan OK'


### PR DESCRIPTION
This updates the Holoscan package to use a Debian package install, instead of the existing pip install.
This enables the C++ runtime and adds the ability to build more complex HoloHub apps using Cmake.

Changes are as follows:
- Switch install from pip -> Debian package
- Add ffmpeg dependency to support ffmpeg-based HoloHub apps
- Correct user guide URL
- Update `docs.md` to show how to run a HoloHub example app
- Update `test.sh` to export the python path so the test works with the Debian package install