### PR TITLE
Extend LD_LIBRARY_PATH with /usr/local/lib/

### DIFF
--- a/packages/jetson-utils/Dockerfile
+++ b/packages/jetson-utils/Dockerfile
@@ -33,5 +33,5 @@ RUN cd jetson-utils && \
     cmake ../ && \
     make -j$(nproc) && \
     make install
-    
-RUN python3 -c 'import jetson_utils'
+
+RUN LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/" python3 -c 'import jetson_utils'


### PR DESCRIPTION
This is necessary in order to successfully import `jetson_utils` during the image build. On the other hand, the `LD_LIBRARY_PATH` modification is not necessary when running container, even though the path `usr/local/lib` is missing.

# Step to reproduce original error

```bash
./jetson-containers build --name=jetson-utils jetson-utils
``` 

# Others

This is probably related to the dusty-nv/jetson-inference#1761.