### PR TITLE
add command line --build-arg functionality

### DIFF
--- a/jetson_containers/build.py
+++ b/jetson_containers/build.py
@@ -38,6 +38,7 @@ parser.add_argument('--name', type=str, default='', help="the name of the output
 parser.add_argument('--base', type=str, default='', help="the base container to use at the beginning of the build chain (default: l4t-jetpack)")
 parser.add_argument('--multiple', action='store_true', help="the specified packages should be built independently as opposed to chained together")
 parser.add_argument('--build-flags', type=str, default='', help="extra flags to pass to 'docker build' commands")
+parser.add_argument('--build-args', type=str, default='', help="container build arguments (--build-arg) as a string of comma separated key:value pairs")
 parser.add_argument('--package-dirs', type=str, default='', help="additional package search directories (comma or colon-separated)")
 
 parser.add_argument('--list-packages', action='store_true', help="show the list of packages that were found under the search directories")
@@ -76,6 +77,14 @@ print(f"-- CUDA_VERSION={CUDA_VERSION}")
 print(f"-- PYTHON_VERSION={PYTHON_VERSION}")
 print(f"-- LSB_RELEASE={LSB_RELEASE} ({LSB_CODENAME})")
 
+# cast build args into dictionary
+if args.build_args:
+    try:
+        key_value_pairs = args.build_args.split(',')
+        args.build_args = {pair.split(':')[0]: pair.split(':')[1] for pair in key_value_pairs}
+    except(ValueError, IndexError):
+        raise argparse.ArgumentTypeError("Invalid dictionary format. Use key1:value1, key2:value2 ...")
+
 # add package directories
 if args.package_dirs:
     package_search_dirs(args.package_dirs)
@@ -100,6 +109,6 @@ if args.list_packages or args.show_packages:
 # build one multi-stage container from chain of packages
 # or launch multiple independent container builds
 if not args.multiple:
-    build_container(args.name, args.packages, args.base, args.build_flags, args.simulate, args.skip_tests, args.test_only, args.push, args.no_github_api)
+    build_container(args.name, args.packages, args.base, args.build_flags, args.build_args, args.simulate, args.skip_tests, args.test_only, args.push, args.no_github_api)
 else:   
-    build_containers(args.name, args.packages, args.base, args.build_flags, args.simulate, args.skip_errors, args.skip_packages, args.skip_tests, args.test_only, args.push)
+    build_containers(args.name, args.packages, args.base, args.build_flags, args.build_args, args.simulate, args.skip_errors, args.skip_packages, args.skip_tests, args.test_only, args.push)

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -22,7 +22,7 @@ from packaging.version import Version
 _NEWLINE_=" \\\n"  # used when building command strings
 
 
-def build_container(name, packages, base=get_l4t_base(), build_flags='', simulate=False, skip_tests=[], test_only=[], push='', no_github_api=False):
+def build_container(name, packages, base=get_l4t_base(), build_flags='', build_args=None, simulate=False, skip_tests=[], test_only=[], push='', no_github_api=False):
     """
     Multi-stage container build that chains together selected packages into one container image.
     For example, `['pytorch', 'tensorflow']` would build a container that had both pytorch and tensorflow in it.
@@ -122,7 +122,11 @@ def build_container(name, packages, base=get_l4t_base(), build_flags='', simulat
             
             if 'build_args' in pkg:
                 cmd += ''.join([f"--build-arg {key}=\"{value}\"" + _NEWLINE_ for key, value in pkg['build_args'].items()])
-            
+
+            if build_args:
+                for key, value in build_args.items():
+                    cmd += f"--build-arg {key}={value}" + _NEWLINE_ 
+
             if 'build_flags' in pkg:
                 cmd += pkg['build_flags'] + _NEWLINE_
                 
@@ -169,7 +173,7 @@ def build_container(name, packages, base=get_l4t_base(), build_flags='', simulat
     return name
     
     
-def build_containers(name, packages, base=get_l4t_base(), build_flags='', simulate=False, skip_errors=False, skip_packages=[], skip_tests=[], test_only=[], push=''):
+def build_containers(name, packages, base=get_l4t_base(), build_flags='', build_args=None, simulate=False, skip_errors=False, skip_packages=[], skip_tests=[], test_only=[], push=''):
     """
     Build separate container images for each of the requested packages (this is typically used in batch building jobs)
     For example, `['pytorch', 'tensorflow']` would build a pytorch container and a tensorflow container.
@@ -203,7 +207,7 @@ def build_containers(name, packages, base=get_l4t_base(), build_flags='', simula
 
     for package in packages:
         try:
-            container_name = build_container(name, package, base, build_flags, simulate, skip_tests, test_only, push) 
+            container_name = build_container(name, package, base, build_flags, build_args, simulate, skip_tests, test_only, push) 
         except Exception as error:
             print(error)
             if not skip_errors:


### PR DESCRIPTION
Added --build-args to argument parser to allow passing build arguments on command line when using 'jetson-containers build'. 