### PR TITLE
Fix ROS_ROOT

### DIFF
--- a/packages/ros/Dockerfile.ros2
+++ b/packages/ros/Dockerfile.ros2
@@ -8,7 +8,7 @@ ARG ROS_PACKAGE=ros_base \
     ROS_VERSION=humble
 
 ENV ROS_DISTRO=${ROS_VERSION} \
-    ROS_ROOT=/opt/ros/${ROS_DISTRO} \
+    ROS_ROOT=/opt/ros/${ROS_VERSION} \
     ROS_PYTHON_VERSION=3 \
     RMW_IMPLEMENTATION=rmw_fastrtps_cpp \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
ROS_DISTRO is not set until the `ENV` command is over so ROS_ROOT is currently set to `/opt/ros/`. This fixes the problem by using ROS_VERSION instead which is set one command above