### PR TITLE
Support `--csi2webcam` option to enables CSI camera as webcam

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,15 +3,119 @@
 # https://docs.docker.com/engine/reference/commandline/run/
 ROOT="$(dirname "$(readlink -f "$0")")"
 
+# Function to clean up background processes
+cleanup() {
+    if [[ ${#BG_PIDS[@]} -gt 0 ]]; then
+        echo "Terminating background processes..."
+        for pid in "${BG_PIDS[@]}"; do
+            kill "$pid"  # Terminate each background process
+            wait "$pid" 2>/dev/null  # Wait for the process to finish
+        done
+    fi
+	sudo modprobe -r v4l2loopback
+}
+
+# Trap signals like INT (Ctrl+C) or TERM to invoke the cleanup function
+trap cleanup INT TERM
+
+# Check for the --csi2webcam option
+csi_to_webcam_conversion=false
+for arg in "$@"; do
+    if [[ "$arg" == "--csi2webcam" ]]; then
+        csi_to_webcam_conversion=true
+        break
+    fi
+done
+
 # check for V4L2 devices
 V4L2_DEVICES=""
 
-for i in {0..9}
-do
-	if [ -a "/dev/video$i" ]; then
-		V4L2_DEVICES="$V4L2_DEVICES --device /dev/video$i "
+if [[ "$csi_to_webcam_conversion" == true ]]; then
+
+	# Check if v4l2loopback-dkms is installed
+	if dpkg -l | grep -q v4l2loopback-dkms; then
+		echo "( v4l2loopback-dkms is installed. )"
+	else
+		echo "[Error] v4l2loopback-dkms is not installed."
+		echo " "
+		echo "Perform the following command to first install v4l2loopback moddule."
+		echo " "
+		echo "    sudo apt update && sudo apt install v4l2loopback-dkms"
+		echo " "
+		exit 1
 	fi
-done
+
+	# Store /dev/video index number for each CSI camera found
+	csi_indexes=()
+	# Store /dev/video* device name for each CSI camera found
+	csi_devices=()
+
+	# Loop through all matching /dev/video* devices
+	for device in /dev/video*; do
+		# Use v4l2-ctl to check if the device supports RG10 (CSI camera format)
+		if v4l2-ctl -d "$device" --list-formats-ext 2>/dev/null | grep -q "RG10"; then
+			echo "$device is a CSI camera (RG10 format)"
+			# Store the device name in array if CSI camera
+			csi_devices+=("$device")
+			# Extract the device index number and add to the csi_devices array
+			dev_index=$(echo "$device" | grep -o '[0-9]\+')
+			csi_indexes+=("$dev_index")
+		else
+			echo "$device is not a CSI camera (likely a webcam)"
+			V4L2_DEVICES="$V4L2_DEVICES --device $device "
+		fi
+	done
+
+	# Load the v4l2loopback module to create as many devices as CSI cameras found in the prior step
+	sudo modprobe v4l2loopback devices=${#csi_indexes[@]} exclusive_caps=1 card_label="Converted from CSI camera"
+
+	# Get all new /dev/video devices created by v4l2loopback
+	new_devices=$(v4l2-ctl --list-devices | grep -A 1 "v4l2loopback" | grep '/dev/video' | awk '{print $1}')
+
+	# add the created v4l2loopback devices
+	if [[ -n "$new_devices" ]]; then
+		for converted_device in $new_devices; do
+			V4L2_DEVICES="$V4L2_DEVICES --device $converted_device "
+		done
+	else
+		echo "No v4l2loopback devices found."
+	fi
+
+	# Start background processes for each CSI camera found
+	i=0
+	for csi_index in "${csi_indexes[@]}"; do
+		echo "Starting background process for CSI camera device number: $csi_index"
+
+		# Run gst-launch-1.0 command in the background, suppressing all output
+		gst-launch-1.0 -v nvarguscamerasrc sensor-id=${csi_index} \
+					! 'video/x-raw(memory:NVMM), format=NV12, width=1640, height=1232, framerate=30/1' \
+					! nvvidconv \
+					! 'video/x-raw, width=1600, height=1200, framerate=30/1', format=I420 \
+					! nvjpegenc \
+					! multipartmux \
+					! multipartdemux single-stream=1 \
+					! "image/jpeg, width=1600, height=1200, parsed=(boolean)true, colorimetry=(string)2:4:7:1, framerate=(fraction)30/1, sof-marker=(int)0" \
+					! v4l2sink device=${new_devices[i]} > /dev/null 2>&1 &
+		# ping google.com > /dev/null 2>&1 &
+
+		# Store the PID of the background process if you want to manage it later
+		BG_PIDS+=($!)
+		echo "BG_PIDS: $BG_PIDS"
+
+		((i++))
+	done
+
+else
+	# Loop through all matching /dev/video* devices
+	for device in /dev/video*; do
+	    if [ -e "$device" ]; then  # Check if the device file exists
+        	V4L2_DEVICES="$V4L2_DEVICES --device $device "
+		fi
+    done
+fi
+
+echo "V4L2_DEVICES: $V4L2_DEVICES"
+echo "csi_indexes: $csi_indexes"
 
 # check for I2C devices
 I2C_DEVICES=""
@@ -67,6 +171,19 @@ else
 	SUDO="sudo"
 fi
 
+# Initialize an empty array for filtered arguments
+filtered_args=()
+
+# Loop through all provided arguments
+for arg in "$@"; do
+    if [[ "$arg" != "--csi2webcam" ]]; then
+        filtered_args+=("$arg")  # Add to the new array if not the argument to remove
+    fi
+done
+
+# Track container ID for `docker wait`
+container_id=""
+
 # run the container
 ARCH=$(uname -i)
 
@@ -91,7 +208,10 @@ if [ $ARCH = "aarch64" ]; then
 		--device /dev/snd \
 		--device /dev/bus/usb \
 		$OPTIONAL_PERMISSION_ARGS $DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $JTOP_SOCKET $EXTRA_FLAGS \
-		"$@"
+		--name my_jetson_container \
+		"${filtered_args[@]}"
+
+	set +x
 
 elif [ $ARCH = "x86_64" ]; then
 
@@ -104,5 +224,18 @@ elif [ $ARCH = "x86_64" ]; then
 		--env NVIDIA_DRIVER_CAPABILITIES=all \
 		--volume $ROOT/data:/data \
 		$OPTIONAL_ARGS $DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $JTOP_SOCKET $EXTRA_FLAGS \
-		"$@"	
+		--name my_jetson_container \
+		"${filtered_args[@]}"
+
+	set +x
+fi
+
+if [[ "$csi_to_webcam_conversion" == true ]]; then
+
+	# Wait for the Docker container to finish (if it exits)
+	docker wait my_jetson_container
+
+	# When Docker container exits, cleanup will be called
+	cleanup
+
 fi


### PR DESCRIPTION
**Motivation**
There are many applications/frameworks that are designed to work with (debayered) V4L2 video devices (like USB webcam) that can simply be accessed using OpenCV.
It would be nice to be able to use Jetson's CSI cameras (which requires debayering) transparently using Jetson's ISP hardware.

**Implementation**

If `--csi2webcam` options is given to `run.sh`:

1. Check how many CSI cameras are hooked up
2. Dynamically create V4L2loopback device as many as the CSI cameras connected
3. Within `run.sh` start background process per V4L2loopback device to execute gstreamer command like:
    ```
	gst-launch-1.0 -v nvarguscamerasrc sensor-id=${csi_index} \
		! 'video/x-raw(memory:NVMM), format=NV12, width=1640, height=1232, framerate=30/1' \
		! nvvidconv \
		! 'video/x-raw, width=1600, height=1200, framerate=30/1', format=I420 \
		! nvjpegenc \
		! multipartmux \
		! multipartdemux single-stream=1 \
		! "image/jpeg, width=1600, height=1200, parsed=(boolean)true, colorimetry=(string)2:4:7:1, framerate=(fraction)30/1, sof-marker=(int)0" \
		! v4l2sink device=${new_devices[i]} 
    ```
4. `docker run` with mounting all the native webcams and v4l2loopback devices
4. Upon `run.sh` termination, kill the background processes and destroy the dynamically created V4L2loopback devices 