### PR TITLE
add skip packages option for building single container

### DIFF
--- a/jetson_containers/build.py
+++ b/jetson_containers/build.py
@@ -109,6 +109,6 @@ if args.list_packages or args.show_packages:
 # build one multi-stage container from chain of packages
 # or launch multiple independent container builds
 if not args.multiple:
-    build_container(args.name, args.packages, args.base, args.build_flags, args.build_args, args.simulate, args.skip_tests, args.test_only, args.push, args.no_github_api)
+    build_container(args.name, args.packages, args.base, args.build_flags, args.build_args, args.simulate, args.skip_tests, args.test_only, args.push, args.no_github_api, args.skip_packages)
 else:   
     build_containers(args.name, args.packages, args.base, args.build_flags, args.build_args, args.simulate, args.skip_errors, args.skip_packages, args.skip_tests, args.test_only, args.push)

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -22,7 +22,7 @@ from packaging.version import Version
 _NEWLINE_=" \\\n"  # used when building command strings
 
 
-def build_container(name, packages, base=get_l4t_base(), build_flags='', build_args=None, simulate=False, skip_tests=[], test_only=[], push='', no_github_api=False):
+def build_container(name, packages, base=get_l4t_base(), build_flags='', build_args=None, simulate=False, skip_tests=[], test_only=[], push='', no_github_api=False, skip_packages=[]):
     """
     Multi-stage container build that chains together selected packages into one container image.
     For example, `['pytorch', 'tensorflow']` would build a container that had both pytorch and tensorflow in it.
@@ -63,7 +63,7 @@ def build_container(name, packages, base=get_l4t_base(), build_flags='', build_a
         base = get_l4t_base()
         
     # add all dependencies to the build tree
-    packages = resolve_dependencies(packages)
+    packages = resolve_dependencies(packages, skip_packages=skip_packages)
     print('-- Building containers ', packages)
     
     # make sure all packages can be found before building any

--- a/jetson_containers/packages.py
+++ b/jetson_containers/packages.py
@@ -270,13 +270,15 @@ def group_packages(packages, key, default=''):
     return grouped
     
         
-def resolve_dependencies(packages, check=True):
+def resolve_dependencies(packages, check=True, skip_packages=[]):
     """
     Recursively expand the list of dependencies to include all sub-dependencies.
     Returns a new list of containers to build which contains all the dependencies.
     
     If check is true, then each dependency will be confirmed to exist, otherwise
     a KeyError exception will be raised with the name of the missing dependency.
+    
+    skip_packages is a list of package names to exclude from the dependency resolution.
     """
     if isinstance(packages, str):
         packages = [packages]
@@ -304,7 +306,7 @@ def resolve_dependencies(packages, check=True):
                     packages.pop(dependency_index)
                     packages.insert(package_index, dependency)
                     return packages, True
-
+        packages = [p for p in packages if not any(fnmatch.fnmatch(p, skip) for skip in skip_packages)]
         return packages, (packages != packages_org)
     
     # iteratively unroll/expand dependencies until the full list is resolved


### PR DESCRIPTION
When building a single stacked container, sometimes it may be useful to skip some dependencies of the containers stacked on top. For example: ros builds depend on opencv, but if the base container already contains opencv then we would rebuild opencv and have multiple conflicting installations.

Ex:
```
jetson-containers build \
    --base=opencv:4.8.1-deb-r36.3.0-cu122 \
    --skip-packages=opencv,python \
    ros:iron-foxglove
```
