### PR TITLE
Fix ML tensorflow build

### DIFF
--- a/packages/ml/tensorflow/build.sh
+++ b/packages/ml/tensorflow/build.sh
@@ -6,6 +6,8 @@ echo "Building Tensorflow ${TENSORFLOW_VERSION}"
 
 # Install LLVM/Clang 17 # Update to 18 when main will be ready. 
 # Tensorflow will support llvm 18 and 19
+wget https://apt.llvm.org/llvm.sh
+chmod u+x llvm.sh
 ./llvm.sh 17 all
 
 echo "Building TensorFlow for Jetson"


### PR DESCRIPTION
When building the `Dockerfile.pip` based images, if tensorflow cannot be installed with pip using the `install.sh` script, it runs the `build.sh` script to build from source. As part of that script, it tries to run a script that doesn't exist.

This PR copies the download logic from `install.sh` that does download and make executable `llvm.sh`, the LLVM install script.

