### PR TITLE
Update AutoAWQ and Transformers

### DIFF
--- a/packages/llm/auto_awq/Dockerfile
+++ b/packages/llm/auto_awq/Dockerfile
@@ -2,7 +2,7 @@
 # name: auto_awq
 # group: llm
 # config: config.py
-# depends: [transformers:4.35.0]
+# depends: [transformers]
 # requires: '>=36'
 # test: test.py
 #---

--- a/packages/llm/auto_awq/Dockerfile
+++ b/packages/llm/auto_awq/Dockerfile
@@ -2,7 +2,7 @@
 # name: auto_awq
 # group: llm
 # config: config.py
-# depends: [transformers]
+# depends: [transformers:4.35.0]
 # requires: '>=36'
 # test: test.py
 #---
@@ -11,9 +11,9 @@ FROM ${BASE_IMAGE}
 
 ARG AUTOAWQ_VERSION \
     AUTOAWQ_KERNELS_VERSION \
-    AUTOAWQ_CUDA_ARCH
+    COMPUTE_CAPABILITIES \
+    FORCE_BUILD=off
 
-COPY build.sh /tmp/build_autoawq.sh
+COPY *.sh /tmp/auto_awq/
 
-RUN pip3 install --no-cache-dir --verbose autoawq-kernels==${AUTOAWQ_KERNELS_VERSION} autoawq==${AUTOAWQ_VERSION} || \
-    /tmp/build_autoawq.sh
+RUN /tmp/auto_awq/install.sh || /tmp/auto_awq/build.sh

--- a/packages/llm/auto_awq/config.py
+++ b/packages/llm/auto_awq/config.py
@@ -1,4 +1,5 @@
-from jetson_containers import CUDA_ARCHITECTURES
+from jetson_containers import update_dependencies, CUDA_ARCHITECTURES
+from packaging.version import Version
 
 def AutoAWQ(version, kernels_version, default=False):
     pkg = package.copy()
@@ -9,6 +10,9 @@ def AutoAWQ(version, kernels_version, default=False):
         'AUTOAWQ_KERNELS_VERSION': kernels_version,
         'COMPUTE_CAPABILITIES': ','.join([str(x) for x in CUDA_ARCHITECTURES]),
     }
+
+    if Version(str(version)) > Version('0.2.6'):
+        pkg['depends'] = update_dependencies(pkg['depends'], ['triton'])
 
     builder = pkg.copy()
     
@@ -22,7 +26,7 @@ def AutoAWQ(version, kernels_version, default=False):
     return pkg, builder
 
 package = [
-    AutoAWQ('0.2.7.post2', '0.0.9', default=False),
-    AutoAWQ('0.2.6', '0.0.8', default=True),
+    AutoAWQ('0.2.7.post2', '0.0.9', default=True),
+    AutoAWQ('0.2.6', '0.0.8', default=False),
     AutoAWQ('0.2.4', '0.0.6', default=False),
 ]

--- a/packages/llm/auto_awq/config.py
+++ b/packages/llm/auto_awq/config.py
@@ -4,18 +4,25 @@ def AutoAWQ(version, kernels_version, default=False):
     pkg = package.copy()
 
     pkg['name'] = f'auto_awq:{version}'
-
-    if default:
-        pkg['alias'] = 'auto_awq'
-    
     pkg['build_args'] = {
         'AUTOAWQ_VERSION': version,
         'AUTOAWQ_KERNELS_VERSION': kernels_version,
-        'AUTOAWQ_CUDA_ARCH': ','.join([str(x) for x in CUDA_ARCHITECTURES])
+        'COMPUTE_CAPABILITIES': ','.join([str(x) for x in CUDA_ARCHITECTURES]),
     }
+
+    builder = pkg.copy()
     
-    return pkg
+    builder['name'] = f'auto_awq:{version}-builder'
+    builder['build_args'] = {**pkg['build_args'], **{'FORCE_BUILD': 'on'}}
+
+    if default:
+        pkg['alias'] = 'auto_awq'
+        builder['alias'] = 'auto_awq:builder'
+    
+    return pkg, builder
 
 package = [
-    AutoAWQ('0.2.4', '0.0.6', default=True),
+    AutoAWQ('0.2.7.post2', '0.0.9', default=False),
+    AutoAWQ('0.2.6', '0.0.8', default=True),
+    AutoAWQ('0.2.4', '0.0.6', default=False),
 ]

--- a/packages/llm/auto_awq/install.sh
+++ b/packages/llm/auto_awq/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# auto_awq
+set -ex
+
+if [ "$FORCE_BUILD" == "on" ]; then
+	echo "Forcing build of autoawq ${AUTOAWQ_VERSION} with autoawq-kernels ${AUTOAWQ_KERNELS_VERSION}"
+	exit 1
+fi
+
+pip3 install --no-cache-dir --verbose autoawq-kernels==${AUTOAWQ_KERNELS_VERSION} autoawq==${AUTOAWQ_VERSION}

--- a/packages/llm/transformers/Dockerfile
+++ b/packages/llm/transformers/Dockerfile
@@ -21,7 +21,9 @@ RUN pip3 install --no-cache-dir --verbose accelerate && \
     \
     # install from pypi, git, ect (sometimes other version got installed)
     pip3 uninstall -y transformers && \
-    pip3 install --no-cache-dir --verbose ${TRANSFORMERS_PACKAGE}==${TRANSFORMERS_VERSION} && \
+    \
+    echo "Installing tranformers $TRANSFORMERS_VERSION (from $TRANSFORMERS_PACKAGE)" && \
+    pip3 install --no-cache-dir --verbose ${TRANSFORMERS_PACKAGE} && \
     \
     # "/usr/local/lib/python3.8/dist-packages/transformers/modeling_utils.py", line 118
     # AttributeError: module 'torch.distributed' has no attribute 'is_initialized'

--- a/packages/llm/transformers/Dockerfile
+++ b/packages/llm/transformers/Dockerfile
@@ -11,9 +11,7 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ARG TRANSFORMERS_PACKAGE=transformers \
-    TRANSFORMERS_VERSION=https://pypi.org/pypi/transformers/json
-
-ADD ${TRANSFORMERS_VERSION} /tmp/transformers_version.json
+    TRANSFORMERS_VERSION
 
 # if you want optimum[exporters,onnxruntime] see the optimum package
 
@@ -23,15 +21,18 @@ RUN pip3 install --no-cache-dir --verbose accelerate && \
     \
     # install from pypi, git, ect (sometimes other version got installed)
     pip3 uninstall -y transformers && \
-    pip3 install --no-cache-dir --verbose ${TRANSFORMERS_PACKAGE} && \
+    pip3 install --no-cache-dir --verbose ${TRANSFORMERS_PACKAGE}==${TRANSFORMERS_VERSION} && \
     \
     # "/usr/local/lib/python3.8/dist-packages/transformers/modeling_utils.py", line 118
     # AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
     PYTHON_ROOT=`pip3 show transformers | grep Location: | cut -d' ' -f2` && \
-    sed -i 's|torch.distributed.is_initialized|torch.distributed.is_available|g' -i ${PYTHON_ROOT}/transformers/modeling_utils.py
+    sed -i \
+        -e 's|torch.distributed.is_initialized|torch.distributed.is_available|g' \
+        ${PYTHON_ROOT}/transformers/modeling_utils.py
     
 # add benchmark script
 COPY huggingface-benchmark.py /usr/local/bin
     
 # make sure it loads
-RUN pip3 show transformers && python3 -c 'import transformers; print(transformers.__version__)'
+RUN pip3 show transformers \
+    && python3 -c 'import transformers; print(transformers.__version__)'

--- a/packages/llm/transformers/config.py
+++ b/packages/llm/transformers/config.py
@@ -55,7 +55,6 @@ def transformers_git(version, repo='huggingface/transformers', branch=None, **kw
 # built-into transformers, use the 'bitsandbytes' or 'auto_gptq' containers directly instead of transformers container
 package = [
     transformers_pypi('latest', default=True),                                  # will always resolve to the latest pypi version
-    transformers_pypi('4.41.2'),                                                # For compatibility with AutoAWQ
     transformers_git('latest', codename='git'),                                                 # will always resolve to the latest git version from huggingface/transformers
     transformers_git('latest', codename='nvgpt', repo='ertkonuk/transformers'),     # will always resolve to the latest git version from ertkonuk/transformers
 ]

--- a/packages/llm/transformers/config.py
+++ b/packages/llm/transformers/config.py
@@ -1,10 +1,11 @@
 from jetson_containers import handle_json_request, github_latest_tag
+from packaging.version import parse
 
-def transformers(version, source=None, requires='>=34', default=False):
+
+def _transformers(version, codename=None, source=None, requires='>=34', default=False):
     pkg = package.copy()
 
-    if version:
-        pkg['name'] += f':{version}'
+    pkg['name'] = f'{package["name"]}:{codename or version}'
 
     pkg['build_args'] = {
         'TRANSFORMERS_PACKAGE': source,
@@ -15,43 +16,46 @@ def transformers(version, source=None, requires='>=34', default=False):
         pkg['requires'] = requires
 
     if default:
-        pkg['alias'] = f'transformers'
+        pkg['alias'] = package['name']
 
     return pkg
 
 
 def transformers_pypi(version, **kwargs):
-    releases = f'https://pypi.org/pypi/transformers/json'
-
     if version == 'latest':
-        data = handle_json_request(releases)
-        version = data['releases'].keys()[-1]
+        data = handle_json_request('https://pypi.org/pypi/transformers/json')
+        # Sort the version keys using `parse` for proper semantic version sorting
+        sorted_versions = sorted(data['releases'].keys(), key=parse)
+        version = sorted_versions[-1]
 
-        print(f'releases: {data['releases'].keys()}')
-        print(f'latest: {version}')
-
-    return transformers(
+    return _transformers(
         version,
-        source=f'transformers',
+        source=f'transformers=={version}',
         **kwargs
     )
 
 
-def transformers_git(version, repo='huggingface/transformers', branch='main', **kwargs):
+def transformers_git(version, repo='huggingface/transformers', branch=None, **kwargs):
     version = github_latest_tag(repo) if version == 'latest' else version
-    return transformers(
+
+    if version.startswith('v'):
+        version = version[1:]
+
+    if branch is None:
+        branch = f'v{version}'
+
+    return _transformers(
         version,
-        source=f'git+https://github.com/{repo}',
+        source=f'git+https://github.com/{repo}@{branch}',
         **kwargs
     )
-
 
 # 11/3/23 - removing 'bitsandbytes' and 'auto_gptq' due to circular dependency and increased load times of
 # anything using transformers if you want to use load_in_8bit/load_in_4bit or AutoGPTQ quantization 
 # built-into transformers, use the 'bitsandbytes' or 'auto_gptq' containers directly instead of transformers container
 package = [
-    transformers_pypi('latest', default=True),                  # will always resolve to the latest pypi version
-    transformers_pypi('4.35.0'),                                # For compatibility with AutoAWQ
-    transformers_git('git'),
-    transformers_git('nvgpt', repo='ertkonuk/transformers'),
+    transformers_pypi('latest', default=True),                                  # will always resolve to the latest pypi version
+    transformers_pypi('4.41.2'),                                                # For compatibility with AutoAWQ
+    transformers_git('latest', codename='git'),                                                 # will always resolve to the latest git version from huggingface/transformers
+    transformers_git('latest', codename='nvgpt', repo='ertkonuk/transformers'),     # will always resolve to the latest git version from ertkonuk/transformers
 ]


### PR DESCRIPTION
#### Summary:
This PR introduces multiple updates to the `auto_awq` and `transformers` packages to improve compatibility, streamline the build process, and enhance maintainability. Key changes include improved handling of dependencies, updated build scripts, and better integration with the latest versions of the respective packages.

---

#### Key Changes:

##### AutoAWQ Updates:
1. **Dockerfile**:
   - Added support for `COMPUTE_CAPABILITIES` and `FORCE_BUILD` arguments for more flexible builds
   - Updated script copying mechanism to include all `.sh` files under `/tmp/auto_awq`


2. **Build Script (`build.sh`)**:
   - Moved output wheels to `/opt/wheels/` for better organization
   - Fixed the typos in `sed -i` command

3. **Install Script (`install.sh`)**:
   - Added a check for `FORCE_BUILD` to enable conditional builds
   - Simplified pip installation logic to prioritize prebuilt wheels

4. **Configuration (`config.py`)**:
   - Added support for dynamically updating dependencies using `update_dependencies`
   - Introduced a builder image for `auto_awq` to handle custom builds with `FORCE_BUILD=on`

---

##### Transformers Updates:
1. **Dockerfile**:
   - Updated installation logic to support a flexible version specification using `TRANSFORMERS_VERSION`

2. **Configuration (`config.py`)**:
   - Introduced `_transformers` helper for dynamic configuration of versions and sources (PyPI, Git)
   - Added functions `transformers_pypi` and `transformers_git` for resolving package versions dynamically

---

#### Breaking Changes:
- The `auto_awq` builder now requires `FORCE_BUILD` to be explicitly set for manual builds ;)

---

#### Benefits:
- Streamlined build processes and better dependency management
- Enhanced flexibility with support for the latest `transformers` and `auto_awq` versions
- Improved organization of build outputs and reduced potential build conflicts

---

#### Testing:
- Verified builds for multiple versions of `auto_awq` (`0.2.7.post2`, `0.2.6`, `0.2.4`)
- Confirmed compatibility with the latest versions of `transformers` (via PyPI and GitHub)

