### PR TITLE
Fixed parse error when passing multiple colons to build args

### DIFF
--- a/jetson_containers/build.py
+++ b/jetson_containers/build.py
@@ -81,7 +81,7 @@ print(f"-- LSB_RELEASE={LSB_RELEASE} ({LSB_CODENAME})")
 if args.build_args:
     try:
         key_value_pairs = args.build_args.split(',')
-        args.build_args = {pair.split(':')[0]: pair.split(':')[1] for pair in key_value_pairs}
+        args.build_args = {pair.split(':')[0]: pair.split(':', maxsplit=1)[1] for pair in key_value_pairs}
     except(ValueError, IndexError):
         raise argparse.ArgumentTypeError("Invalid dictionary format. Use key1:value1, key2:value2 ...")
 


### PR DESCRIPTION
This line has a bug while the value contains colons, for example "http_proxy:http://127.0.0.1:7897/". Then pair.split(':')[1] has the wrong value "http" instead of "http://127.0.0.1:7897/". Passing the maxsplit argument to the split function can fix this bug.