### PR TITLE
add `mlc` `0.1.4` (`1825fed`)

### DIFF
--- a/packages/llm/mlc/config.py
+++ b/packages/llm/mlc/config.py
@@ -34,5 +34,6 @@ package = [
     mlc('3403a4e', 'patches/3403a4e.diff', version='0.1.1', tvm='0.16.0', requires='>=36'),  # 4/15/2024
     mlc('9336b4a', 'patches/9336b4a.diff', version='0.1.2', tvm='0.18.0', requires='>=36'),  # 9/25/2024
     mlc('6da6aca', 'patches/6da6aca.diff', version='0.1.3', tvm='0.18.1', requires='>=36'),  # 10/18/2024
+    mlc('1825fed', 'patches/1825fed.diff', version='0.1.4', tvm='0.19.1', requires='>=36'),  # 12/20/2024
 ]
 

--- a/packages/llm/mlc/patches/1825fed.diff
+++ b/packages/llm/mlc/patches/1825fed.diff
@@ -1,0 +1,318 @@
+Submodule 3rdparty/tvm contains modified content
+Submodule 3rdparty/cutlass contains modified content
+diff --git a/3rdparty/tvm/3rdparty/cutlass/CMakeLists.txt b/3rdparty/tvm/3rdparty/cutlass/CMakeLists.txt
+index ed759073..e0c8b00d 100755
+--- a/3rdparty/tvm/3rdparty/cutlass/CMakeLists.txt
++++ b/3rdparty/tvm/3rdparty/cutlass/CMakeLists.txt
+@@ -138,13 +138,7 @@ set(CUTLASS_ENABLE_GTEST_UNIT_TESTS ${CUTLASS_ENABLE_TESTS} CACHE BOOL "Enable C
+ 
+ set(CUTLASS_NVCC_ARCHS_SUPPORTED "")
+ if (CUDA_VERSION VERSION_GREATER_EQUAL 11.4 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 70 72 75 80 86 87)
+-endif()
+-if (CUDA_VERSION VERSION_GREATER_EQUAL 11.8 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 89 90)
+-endif()
+-if (CUDA_VERSION VERSION_GREATER_EQUAL 12.0 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 90a)
++  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 87)
+ endif()
+ set(CUTLASS_NVCC_ARCHS ${CUTLASS_NVCC_ARCHS_SUPPORTED} CACHE STRING "The SM architectures requested.")
+ set(CUTLASS_NVCC_ARCHS_ENABLED ${CUTLASS_NVCC_ARCHS} CACHE STRING "The SM architectures to build code for.")
+Submodule 3rdparty/cutlass_fpA_intB_gemm contains modified content
+Submodule cutlass contains modified content
+diff --git a/3rdparty/tvm/3rdparty/cutlass_fpA_intB_gemm/cutlass/CMakeLists.txt b/3rdparty/tvm/3rdparty/cutlass_fpA_intB_gemm/cutlass/CMakeLists.txt
+index 30e261c2..17806cd5 100755
+--- a/3rdparty/tvm/3rdparty/cutlass_fpA_intB_gemm/cutlass/CMakeLists.txt
++++ b/3rdparty/tvm/3rdparty/cutlass_fpA_intB_gemm/cutlass/CMakeLists.txt
+@@ -101,26 +101,8 @@ if (CUTLASS_ENABLE_TESTS)
+ endif()
+ 
+ set(CUTLASS_NVCC_ARCHS_SUPPORTED "")
+-if (NOT CUDA_VERSION VERSION_LESS 7.5)
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 53)
+-endif()
+-if (NOT CUDA_VERSION VERSION_LESS 8.0)
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 60 61)
+-endif()
+-if (NOT CUDA_VERSION VERSION_LESS 9.0)
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 70)
+-endif()
+-if (NOT CUDA_VERSION VERSION_LESS 9.2)
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 72)
+-endif()
+-if (NOT CUDA_VERSION VERSION_LESS 10.0)
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 75)
+-endif()
+-if (NOT CUDA_VERSION VERSION_LESS 11.0)
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 80)
+-endif()
+-if (NOT CUDA_VERSION VERSION_LESS 11.1 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 86)
++if (CUDA_VERSION VERSION_GREATER_EQUAL 11.4 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
++  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 87)
+ endif()
+ set(CUTLASS_NVCC_ARCHS ${CUTLASS_NVCC_ARCHS_SUPPORTED} CACHE STRING "The SM architectures requested.")
+ set(CUTLASS_NVCC_ARCHS_ENABLED ${CUTLASS_NVCC_ARCHS} CACHE STRING "The SM architectures to build code for.")
+Submodule 3rdparty/flashinfer contains modified content
+diff --git a/3rdparty/tvm/3rdparty/flashinfer/include/flashinfer/mma.cuh b/3rdparty/tvm/3rdparty/flashinfer/include/flashinfer/mma.cuh
+index 82f457a..0919eb7 100644
+--- a/3rdparty/tvm/3rdparty/flashinfer/include/flashinfer/mma.cuh
++++ b/3rdparty/tvm/3rdparty/flashinfer/include/flashinfer/mma.cuh
+@@ -29,11 +29,13 @@ namespace flashinfer {
+ 
+ namespace mma {
+ 
++#if 0
+ #if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120400)
+ #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 890))
+ #define FLASHINFER_MMA_F8F8F32_M16N8K32_ENABLED
+ #endif
+ #endif
++#endif
+ 
+ #if (__CUDACC_VER_MAJOR__ >= 11)
+ #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
+Submodule 3rdparty/libflash_attn contains modified content
+Submodule cutlass contains modified content
+diff --git a/3rdparty/tvm/3rdparty/libflash_attn/cutlass/CMakeLists.txt b/3rdparty/tvm/3rdparty/libflash_attn/cutlass/CMakeLists.txt
+index 2d4f9cc3..21328555 100755
+--- a/3rdparty/tvm/3rdparty/libflash_attn/cutlass/CMakeLists.txt
++++ b/3rdparty/tvm/3rdparty/libflash_attn/cutlass/CMakeLists.txt
+@@ -121,15 +121,7 @@ endif()
+ ################################################################################
+ 
+ set(CUTLASS_NVCC_ARCHS_SUPPORTED "")
+-if (CUDA_VERSION VERSION_GREATER_EQUAL 11.4 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 70 72 75 80 86 87)
+-endif()
+-if (CUDA_VERSION VERSION_GREATER_EQUAL 11.8 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 89 90)
+-endif()
+-if (CUDA_VERSION VERSION_GREATER_EQUAL 12.0 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+-  list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 90a)
+-endif()
++list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 87)
+ set(CUTLASS_NVCC_ARCHS ${CUTLASS_NVCC_ARCHS_SUPPORTED} CACHE STRING "The SM architectures requested.")
+ set(CUTLASS_NVCC_ARCHS_ENABLED ${CUTLASS_NVCC_ARCHS} CACHE STRING "The SM architectures to build code for.")
+ 
+diff --git a/3rdparty/tvm/3rdparty/libflash_attn/cutlass/include/cute/layout_composed.hpp b/3rdparty/tvm/3rdparty/libflash_attn/cutlass/include/cute/layout_composed.hpp
+index 7b3b6f4f..9fb29af1 100644
+--- a/3rdparty/tvm/3rdparty/libflash_attn/cutlass/include/cute/layout_composed.hpp
++++ b/3rdparty/tvm/3rdparty/libflash_attn/cutlass/include/cute/layout_composed.hpp
+@@ -99,7 +99,9 @@ struct ComposedLayout : private cute::tuple<LayoutA, Offset, LayoutB>  // EBO fo
+   // Doesn't really make sense to ask for the strides of this "layout"
+   CUTE_HOST_DEVICE constexpr
+   decltype(auto)
+-  stride() const = delete;
++  stride() const /*= delete;*/ {
++    return layout_b().stride();
++  }
+ 
+   //
+   // Mappings
+@@ -228,7 +230,10 @@ shape(ComposedLayout<A,O,B> const& layout)
+ template <int... Is, class Fn, class O, class Layout>
+ CUTE_HOST_DEVICE constexpr
+ decltype(auto)
+-stride(ComposedLayout<Fn,O,Layout> const& layout) = delete;
++stride(ComposedLayout<Fn,O,Layout> const& layout) /*= delete;*/
++{
++  return stride<Is...>(layout.layout_b());
++}
+ 
+ // Return the number of elements in a mode
+ template <int... Is, class A, class O, class B>
+diff --git a/3rdparty/tvm/3rdparty/libflash_attn/src/CMakeLists.txt b/3rdparty/tvm/3rdparty/libflash_attn/src/CMakeLists.txt
+index ba2ac1a..d2775e4 100644
+--- a/3rdparty/tvm/3rdparty/libflash_attn/src/CMakeLists.txt
++++ b/3rdparty/tvm/3rdparty/libflash_attn/src/CMakeLists.txt
+@@ -1,6 +1,4 @@
+-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr --expt-relaxed-constexpr --use_fast_math -t 8 \
+-                      -gencode=arch=compute_80,code=\\\"sm_80,compute_80\\\" \
+-                      ")
++set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr --expt-relaxed-constexpr --use_fast_math -t 8")
+ 
+ include_directories(${CUTLASS_DIR}/include)
+ include_directories(../include)
+@@ -17,4 +15,4 @@ add_library(flash_attn SHARED
+   flash_fwd_hdim96_fp16_sm80.cu
+ )
+ 
+-set_target_properties(flash_attn PROPERTIES CUDA_ARCHITECTURES "80")
++
+diff --git a/3rdparty/tvm/3rdparty/libflash_attn/src/static_switch.h b/3rdparty/tvm/3rdparty/libflash_attn/src/static_switch.h
+index b4a4b48..7a05833 100644
+--- a/3rdparty/tvm/3rdparty/libflash_attn/src/static_switch.h
++++ b/3rdparty/tvm/3rdparty/libflash_attn/src/static_switch.h
+@@ -16,10 +16,10 @@
+ #define BOOL_SWITCH(COND, CONST_NAME, ...)                                           \
+     [&] {                                                                            \
+         if (COND) {                                                                  \
+-            constexpr bool CONST_NAME = true;                                        \
++            constexpr static bool CONST_NAME = true;                                 \
+             return __VA_ARGS__();                                                    \
+         } else {                                                                     \
+-            constexpr bool CONST_NAME = false;                                       \
++            constexpr static bool CONST_NAME = false;                                \
+             return __VA_ARGS__();                                                    \
+         }                                                                            \
+     }()
+@@ -38,28 +38,28 @@
+ #define FWD_HEADDIM_SWITCH(HEADDIM, ...)  \
+     [&] {                                 \
+         if (HEADDIM <= 32) {              \
+-            constexpr int kHeadDim = 32;  \
++            constexpr static int kHeadDim = 32;  \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 64) {       \
+-            constexpr int kHeadDim = 64;  \
++            constexpr static int kHeadDim = 64;  \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 96) {       \
+-            constexpr int kHeadDim = 96;  \
++            constexpr static int kHeadDim = 96;  \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 128) {      \
+-            constexpr int kHeadDim = 128; \
++            constexpr static int kHeadDim = 128; \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 160) {      \
+-            constexpr int kHeadDim = 160; \
++            constexpr static int kHeadDim = 160; \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 192) {      \
+-            constexpr int kHeadDim = 192; \
++            constexpr static int kHeadDim = 192; \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 224) {      \
+-            constexpr int kHeadDim = 224; \
++            constexpr static int kHeadDim = 224; \
+             return __VA_ARGS__();         \
+         } else if (HEADDIM <= 256) {      \
+-            constexpr int kHeadDim = 256; \
++            constexpr static int kHeadDim = 256; \
+             return __VA_ARGS__();         \
+         }                                 \
+     }()
+diff --git a/3rdparty/tvm/CMakeLists.txt b/3rdparty/tvm/CMakeLists.txt
+index 09c5104be7..3d4be2b57d 100644
+--- a/3rdparty/tvm/CMakeLists.txt
++++ b/3rdparty/tvm/CMakeLists.txt
+@@ -964,7 +964,7 @@ if(USE_ROCM AND USE_RCCL)
+ endif()
+ 
+ 
+-option(USE_FLASHINFER "Build TVM with FlashInfer" OFF)
++option(USE_FLASHINFER "Build TVM with FlashInfer" ON)
+ if (USE_FLASHINFER STREQUAL "ON")
+   message(STATUS "Build with FlashInfer")
+   set(FLASHINFER_TVM_BINDING ON)
+diff --git a/3rdparty/tvm/python/setup.py b/3rdparty/tvm/python/setup.py
+index 55f29c651a..9cdf7243fc 100644
+--- a/3rdparty/tvm/python/setup.py
++++ b/3rdparty/tvm/python/setup.py
+@@ -128,7 +128,7 @@ def _remove_path(path):
+ 
+ 
+ LIB_LIST, __version__ = get_lib_path()
+-__version__ = git_describe_version(__version__)
++# __version__ = git_describe_version(__version__)
+ 
+ 
+ def config_cython():
+diff --git a/3rdparty/tvm/python/tvm/_ffi/libinfo.py b/3rdparty/tvm/python/tvm/_ffi/libinfo.py
+index f29ddaab72..4089fb4ad3 100644
+--- a/3rdparty/tvm/python/tvm/_ffi/libinfo.py
++++ b/3rdparty/tvm/python/tvm/_ffi/libinfo.py
+@@ -247,4 +247,4 @@ def find_include_path(name=None, search_path=None, optional=False):
+ # We use the version of the incoming release for code
+ # that is under development.
+ # The following line is set by tvm/python/update_version.py
+-__version__ = "0.19.dev0"
++__version__ = "0.19.1"
+diff --git a/3rdparty/tvm/version.py b/3rdparty/tvm/version.py
+index c8151769ba..65065d2b10 100644
+--- a/3rdparty/tvm/version.py
++++ b/3rdparty/tvm/version.py
+@@ -44,7 +44,7 @@ import subprocess
+ # Two tag formats are supported:
+ # - vMAJ.MIN.PATCH (e.g. v0.8.0) or
+ # - vMAJ.MIN.devN (e.g. v0.8.dev0)
+-__version__ = "0.19.dev0"
++__version__ = "0.19.1"
+ 
+ # ---------------------------------------------------
+ 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 08eef03b..5b33ae95 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,13 +47,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ # tvm runtime config: minimize runtime components
+ set(USE_RPC OFF)
+ set(USE_MICRO OFF)
+-set(USE_GRAPH_EXECUTOR OFF)
++#set(USE_GRAPH_EXECUTOR OFF)
+ set(USE_GRAPH_EXECUTOR_DEBUG OFF)
+ set(USE_AOT_EXECUTOR OFF)
+ set(USE_PROFILER OFF)
+ set(USE_GTEST OFF)
+ set(USE_LIBBACKTRACE OFF)
+-set(BUILD_DUMMY_LIBTVM ON)
++#set(BUILD_DUMMY_LIBTVM ON)
+ if (NOT DEFINED TVM_SOURCE_DIR)
+   if(DEFINED ENV{TVM_SOURCE_DIR})
+     set(TVM_SOURCE_DIR "$ENV{TVM_SOURCE_DIR}")
+diff --git a/python/mlc_llm/libinfo.py b/python/mlc_llm/libinfo.py
+index 2212d8c7..f5ff1593 100644
+--- a/python/mlc_llm/libinfo.py
++++ b/python/mlc_llm/libinfo.py
+@@ -4,7 +4,7 @@
+ import os
+ import sys
+ 
+-__version__ = "0.1.dev0"
++__version__ = "0.1.4"
+ MLC_LIBRARY_PATH = os.environ.get("MLC_LIBRARY_PATH", None)
+ 
+ 
+diff --git a/python/mlc_llm/quantization/ft_quantization.py b/python/mlc_llm/quantization/ft_quantization.py
+index 4a158460..7cd8fc6a 100644
+--- a/python/mlc_llm/quantization/ft_quantization.py
++++ b/python/mlc_llm/quantization/ft_quantization.py
+@@ -207,7 +207,7 @@ class FTQuantize:  # pylint: disable=too-many-instance-attributes
+                                 relax.call_pure_packed(
+                                     "cutlass.ft_preprocess_weight",
+                                     lv1,
+-                                    detect_cuda_arch_list(target=target)[0],
++                                    int(detect_cuda_arch_list(target=target)[0]),
+                                     DataType(self.quantize_dtype).bits == 4,
+                                     sinfo_args=lv1.struct_info,
+                                 )
+diff --git a/python/setup.py b/python/setup.py
+index 9022920f..94b67f58 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -47,7 +47,7 @@ def git_describe_version(original_version):
+ 
+ 
+ LIB_LIST, __version__ = get_lib_path()
+-__version__ = git_describe_version(__version__)
++# __version__ = git_describe_version(__version__)
+ 
+ 
+ class BinaryDistribution(Distribution):
+diff --git a/version.py b/version.py
+index c7868f84..dacfaf08 100644
+--- a/version.py
++++ b/version.py
+@@ -20,7 +20,7 @@ import subprocess
+ 
+ # ---------------------------------------------------
+ 
+-__version__ = "0.1.dev0"
++__version__ = "0.1.4"
+ PROJ_ROOT = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+ 
+ 


### PR DESCRIPTION
Adds latest `mlc` commit as `0.1.4` (https://github.com/mlc-ai/mlc-llm/commit/1825fed682ea2217cf65ee082ffcdb4090f53ec5) with support for [Nemotron](https://github.com/mlc-ai/mlc-llm/pull/3069) architecture.

I'm just closing the loop ;)