### PR TITLE
fix tensorflow pip install (doesn't work on any JP/L4T Versions)

### DIFF
--- a/packages/ml/tensorflow/Dockerfile
+++ b/packages/ml/tensorflow/Dockerfile
@@ -18,6 +18,7 @@ ARG TENSORFLOW_URL \
     MAKEFLAGS=-j$(nproc) \
     FORCE_BUILD
 
+COPY link_cuda.sh /tmp/tensorflow/
 COPY install.sh /tmp/tensorflow/
 
 RUN /tmp/tensorflow/install.sh

--- a/packages/ml/tensorflow/install.sh
+++ b/packages/ml/tensorflow/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-bash /tmp/TENSORFLOW/link_cuda.sh
+bash /tmp/tensorflow/link_cuda.sh
 
 wget https://apt.llvm.org/llvm.sh
 chmod u+x llvm.sh
@@ -43,7 +43,7 @@ if [ "$FORCE_BUILD" == "on" ]; then
 fi
 
 # if TENSORFLOW_VERSION <= 2.16.1 download the wheel from the mirror if not # install from the Jetson PyPI server ($PIP_INSTALL_URL)
-if [ $(echo "${TENSORFLOW_VERSION} <= 2.16.1" | bc) -eq 1 ]; then
+if dpkg --compare-versions "${TENSORFLOW_VERSION}" le "2.16.1"; then
     pip3 install --no-cache-dir 'setuptools==68.2.2'
     H5PY_SETUP_REQUIRES=0 pip3 install --no-cache-dir --verbose h5py
     pip3 install --no-cache-dir --verbose future==0.18.2 mock==3.0.5 keras_preprocessing==1.1.2 keras_applications==1.0.8 gast==0.4.0 futures pybind11


### PR DESCRIPTION
Build command:
```
user@host:~/jetson-containers/logs/20241226_221017/build$ cat ros_humble-ros-base-l4t-r36.3.0-tensorflow2.sh
#!/usr/bin/env bash

DOCKER_BUILDKIT=0 docker build --network=host --tag ros:humble-ros-base-l4t-r36.3.0-tensorflow2 \
--file /home/aero/jetson-containers/packages/ml/tensorflow/Dockerfile \
--build-arg BASE_IMAGE=ros:humble-ros-base-l4t-r36.3.0-protobuf_cpp \
--build-arg TENSORFLOW_VERSION="2.16.1" \
--build-arg TENSORFLOW_URL="https://developer.download.nvidia.com/compute/redist/jp/v60/tensorflow/tensorflow-2.16.1+nv24.06-cp310-cp310-linux_aarch64.whl" \
--build-arg TENSORFLOW_WHL="tensorflow-2.16.1+nv24.06-cp310-cp310-linux_aarch64.whl" \
--build-arg PYTHON_VERSION_MAJOR="3" \
--build-arg PYTHON_VERSION_MINOR="10" \
--build-arg FORCE_BUILD="off" \
/home/aero/jetson-containers/packages/ml/tensorflow \
2>&1 | tee /home/aero/jetson-containers/logs/20241226_221017/build/ros_humble-ros-base-l4t-r36.3.0-tensorflow2.txt; exit ${PIPESTATUS[0]}
```

Result:
```
 cat ros_humble-ros-base-l4t-r36.3.0-tensorflow2.txt
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  61.95kB
Step 1/5 : ARG BASE_IMAGE
Step 2/5 : FROM ${BASE_IMAGE}
 ---> 7d00558e15a1
Step 3/5 : ARG TENSORFLOW_URL     TENSORFLOW_WHL     HDF5_DIR="/usr/lib/aarch64-linux-gnu/hdf5/serial/"     MAKEFLAGS=-j$(nproc)     FORCE_BUILD
 ---> Running in 7997ed85083c
 ---> Removed intermediate container 7997ed85083c
 ---> 401a01062b21
Step 4/5 : COPY install.sh /tmp/tensorflow/
 ---> 5eb0c716e22e
Step 5/5 : RUN /tmp/tensorflow/install.sh
 ---> Running in 3fab2073b17b
+ bash /tmp/TENSORFLOW/link_cuda.sh
bash: /tmp/TENSORFLOW/link_cuda.sh: No such file or directory
The command '/bin/sh -c /tmp/tensorflow/install.sh' returned a non-zero code: 127
```


Which then revealed the following error in the version comparison (after resolving the previous error by copying link_cuda.sh to the Docker build)

```
+ apt-get clean
+ '[' off == on ']'
++ echo ' <= 2.16.1'
++ bc
(standard_in) 1: syntax error
+ '[' -eq 1 ']'
/tmp/tensorflow/install.sh: line 47: [: -eq: unary operator expected
+ pip3 install --no-cache-dir --verbose
```

Which then lead to a successful install/test on JP6.1 (CUDA 12.6)

root cause was that we were trying to do a version comparison using bc, which only supports decimals
move to using dpkg --compare-versions


Unknown if link_cuda.sh is needed for the install, but fixed the copy and it resulted in a successful build.
link_cuda.sh needs modifications to support different cuda versions, leaving unchanged as intended direction is not known