### PR TITLE
Micromamba and `uv` for Python package management

### DIFF
--- a/packages/build/python/Dockerfile
+++ b/packages/build/python/Dockerfile
@@ -2,7 +2,7 @@
 # name: python
 # group: build
 # depends: [build-essential, pip_cache]
-# notes: installs core `python3` packages and `pip`
+# notes: installs core `python`, `uv` and `pip` in a conda environment
 #---
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
@@ -22,9 +22,10 @@ ENV PYTHON_VERSION=${PYTHON_VERSION_ARG} \
     TWINE_NON_INTERACTIVE=1 \
     DEBIAN_FRONTEND=noninteractive \
     PATH=/opt/conda/bin:$PATH \
-    CONDA_PREFIX=/opt/conda \
     MAMBA_ROOT_PREFIX=/opt/conda \
-    MAMBA_EXE=/usr/local/bin/micromamba
+    MAMBA_EXE=/usr/local/bin/micromamba \
+    CONDA_PREFIX=/opt/conda \
+    UV_COMPILE_BYTECODE=1
 
 COPY install.sh /tmp/install_python.sh
 RUN /tmp/install_python.sh

--- a/packages/build/python/Dockerfile
+++ b/packages/build/python/Dockerfile
@@ -20,7 +20,11 @@ ENV PYTHON_VERSION=${PYTHON_VERSION_ARG} \
     PIP_CACHE_PURGE=true \
     PIP_ROOT_USER_ACTION=ignore \
     TWINE_NON_INTERACTIVE=1 \
-    DEBIAN_FRONTEND=noninteractive
+    DEBIAN_FRONTEND=noninteractive \
+    PATH=/opt/conda/bin:$PATH \
+    CONDA_PREFIX=/opt/conda \
+    MAMBA_ROOT_PREFIX=/opt/conda \
+    MAMBA_EXE=/usr/local/bin/micromamba
 
-COPY install.sh /tmp/install_python.sh 
+COPY install.sh /tmp/install_python.sh
 RUN /tmp/install_python.sh

--- a/packages/build/python/config.py
+++ b/packages/build/python/config.py
@@ -7,13 +7,13 @@ def python(version, requires=None) -> list:
 
     pkg['name'] = f'python:{version}'
     pkg['build_args'] = {'PYTHON_VERSION_ARG': version}
-    
+
     if Version(version) == PYTHON_VERSION:
         pkg['alias'] = 'python'
 
     if requires:
         pkg['requires'] = requires
-        
+
     return pkg
 
 package = [


### PR DESCRIPTION
This PR includes significant improvement to the Python build process, transitioning from using `apt-get` to Micromamba for easier python environment management (see https://github.com/dusty-nv/jetson-containers/issues/796). The key changes involve using Micromamba to install Python along with `pip` and `uv`. This allows `uv` as drop-in replacement to replace `pip` for much faster builds and better extensibility to other projects. The python environment is set at `/opt/conda/`, and all current code using `pip3 install` has been tested to still work.

### Transition to Micromamba:

- [x] [`packages/build/python/Dockerfile`](diffhunk://#diff-a6d142cd91914997bc54382a386c78ffffa142db0d07dbfd28180aff4b53ed87L5-R5): Updated to install core `python`, `uv`, and `pip` in a conda environment. Added environment variables for Micromamba binary and Conda Python environment path for `uv`.
- [x] [`packages/build/python/install.sh`](diffhunk://#diff-c555c4683751d2062ffc86511af5397476ea2c30185073c3753222d61c740b50L2-L54): Replaced `apt-get` commands with Micromamba commands for installing Python and core packages. Added Micromamba initialization to `/etc/profile.d` for all shells and created symbolic links for `python` and `pip`.
- [x] Optimizing `uv` in containers by [compiling bytecode](https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode) 
- [ ] Remove all `apt-get` install of python-* packages
- [ ] Replace all `pip3 install` to `uv pip install`