### PR TITLE
Install CUDA in container

### DIFF
--- a/packages/llm/ollama/Dockerfile
+++ b/packages/llm/ollama/Dockerfile
@@ -2,6 +2,7 @@
 # name: ollama
 # group: llm
 # config: config.py
+# depends: cuda
 # requires: '>=34.1.0'
 # docs: docs.md
 #---


### PR DESCRIPTION
Installs CUDA by specifying the package dependency to make Ollama enable GPU.
(Ollama installer CUDA runtimes, but somehow they are not recognized in the container)