### PR TITLE
fix wrong `ROOT` variable in `run.sh` shell script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # pass-through commands to 'docker run' with some defaults
 # https://docs.docker.com/engine/reference/commandline/run/
-ROOT="$(dirname $(dirname "$(readlink -f "$0")") )"
+ROOT="$(dirname "$(readlink -f "$0")")"
 
 # Function to clean up background processes
 cleanup() {


### PR DESCRIPTION
Fixes the `ROOT` variable in `run.sh` script.

It was originally changed in https://github.com/dusty-nv/jetson-containers/commit/2a996bc864f89e72420d4714c44f59aa749e84f8 while script was moved. Later @dusty-nv moved the `run.sh` file back into repo root [without reverting code changes](https://github.com/dusty-nv/jetson-containers/commit/9aafb147f57c6e32c2fbe29d3aebda535539f94d) xD