### PR TITLE
Limit video player to fit within the window without breaking the layout

### DIFF
--- a/packages/llm/local_llm/web/templates/video_query.html
+++ b/packages/llm/local_llm/web/templates/video_query.html
@@ -146,6 +146,10 @@
         top:10px;
       }
       
+      #video-player {
+        max-width:100%;
+      }
+      
       .select2-container--default .select2-selection--multiple, .select2-results {
         color: #222222;
         scrollbar-color: #AAAAAA #EEEEEE;


### PR DESCRIPTION
If the video input is a high-resolution or 16:9 video, somehow "video-player" may exceed the "webrtc_player" window area, making the player larger than the window and partially covered by the NanoDB area, if enable "NanoDB Integration".