### PR TITLE
Fix issues when building containers python:r36.4.3 and tritonserver:r36.4.3

### DIFF
--- a/packages/build/python/install.sh
+++ b/packages/build/python/install.sh
@@ -25,9 +25,9 @@ fi
 # path 3:  Python 3.12 for 24.04
 curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} || \
 curl -sS https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3.6 || \
-apt-get install -y --no-install-recommends python3-venv && \
+( apt-get install -y --no-install-recommends python3-venv && \
 python3 -m venv /opt/venv && source /opt/venv/bin/activate && \
-curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
+curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} )
 
 rm -rf /var/lib/apt/lists/*
 apt-get clean

--- a/packages/ml/tritonserver/Dockerfile
+++ b/packages/ml/tritonserver/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     && apt-get clean
 
 RUN pip3 install --upgrade --no-cache-dir --verbose wheel setuptools && \
-    pip3 install --upgrade --no-cache-dir --verbose grpcio-tools numpy attrdict pillow
+    pip3 install --upgrade --no-cache-dir --verbose grpcio-tools "numpy<2" attrdict pillow
  
 ENV PATH="$PATH:/opt/tritonserver/bin" 
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/llvm-8/lib:/opt/tritonserver/lib"

--- a/packages/ml/tritonserver/config.py
+++ b/packages/ml/tritonserver/config.py
@@ -7,8 +7,8 @@ TRITON_CLIENTS = 'clients'
 
 if L4T_VERSION >= Version('36.4.3'): # JetPack 6.2 DP
     # https://github.com/triton-inference-server/server/releases/tag/v2.54.0
-    TRITON_URL = 'https://github.com/triton-inference-server/server/releases/download/v2.54.0/tritonserver2.54.0-igpu.tgz'
-    TRITON_TAR = 'tritonserver2.54.0-igpu.tgz'
+    TRITON_URL = 'https://github.com/triton-inference-server/server/releases/download/v2.54.0/tritonserver2.54.0-igpu.tar'
+    TRITON_TAR = 'tritonserver2.54.0-igpu.tar'
     TRITON_CLIENTS = 'tritonserver/clients'
 elif L4T_VERSION == Version('36.2.0'): # JetPack 6.0 DP
     # https://github.com/triton-inference-server/server/releases/tag/v2.42.0


### PR DESCRIPTION
When building python:r36.4.3 (python3.10), the python installer script (install.sh) gives an error due to the fact that "path 3: Python 3.12 for 24.04" will also be executed partially.

When building tritonserver:r36.4.3, the tar file .tgz cannot be found but .tar can be.

When building tritonserver:r36.4.3, pip conflict showing that "numpy<2" is required.