### PR TITLE
fix issues when building deepstream:r36.4.3 (for deepstream 7.1)

### DIFF
--- a/packages/multimedia/deepstream/Dockerfile
+++ b/packages/multimedia/deepstream/Dockerfile
@@ -15,6 +15,11 @@ ARG DEEPSTREAM_URL
 ARG DEEPSTREAM_TAR
 ARG DEEPSTREAM_VERSION
 
+# Migrate glib to newer version (2.76.6), as suggested in Deepstream Installation guide:
+#   https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html#migrate-glib-to-newer-version
+COPY upgrade_glib.sh /tmp/upgrade_glib.sh 
+RUN /tmp/upgrade_glib.sh
+
 RUN wget --quiet --show-progress --progress=bar:force:noscroll --no-check-certificate ${DEEPSTREAM_URL} -O ${DEEPSTREAM_TAR} && \
     tar -xvf ${DEEPSTREAM_TAR} -C / && \
     rm ${DEEPSTREAM_TAR}
@@ -62,18 +67,43 @@ ARG PYDS_VERSION
 ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
 
-RUN cd /opt/nvidia/deepstream/deepstream/sources && \
-    git clone --branch ${PYDS_VERSION} --recursive --depth=1 https://github.com/NVIDIA-AI-IOT/deepstream_python_apps && \
-    cd deepstream_python_apps/bindings && \
-    mkdir build && \
-    cd build && \
-    cmake ../ \
-        -DDS_PATH=/opt/nvidia/deepstream/deepstream \
-	   -DPIP_PLATFORM=linux_aarch64 \
-	   -DPYTHON_MAJOR_VERSION=${PYTHON_VERSION_MAJOR} \
-	   -DPYTHON_MINOR_VERSION=${PYTHON_VERSION_MINOR} && \
-    make -j$(nproc) && \
-    pip3 install --verbose ./pyds-*-py3-none*.whl
+# The repo https://github.com/NVIDIA-AI-IOT/deepstream_python_apps no longer support deepstream version below 7.1,
+# and the recommended method for building the python binding is to use "python3 -m build", according to:
+#    https://github.com/NVIDIA-AI-IOT/deepstream_python_apps/blob/master/bindings/README.md
+# For previous deepstream versions, we need to download from the "releases" section.
+RUN if [ "${PYDS_VERSION}" = "1.2.0" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            python3-dev \
+            python-gi-dev \
+            meson \
+            python3-pip \
+            cmake \
+            autoconf \
+            automake \
+            libgirepository1.0-dev  \
+        && rm -rf /var/lib/apt/lists/* \
+        && apt-get clean && \
+        pip3 install build && \
+        cd /opt/nvidia/deepstream/deepstream/sources && \
+        git clone https://github.com/NVIDIA-AI-IOT/deepstream_python_apps && \
+        cd /opt/nvidia/deepstream/deepstream/sources/deepstream_python_apps && \
+        git submodule update --init && \
+        python3 bindings/3rdparty/git-partial-submodule/git-partial-submodule.py restore-sparse && \
+        cd bindings/3rdparty/gstreamer/subprojects/gst-python/ && \
+        meson setup build && \
+        cd build && \
+        ninja && \
+        ninja install && \
+        cd /opt/nvidia/deepstream/deepstream/sources/deepstream_python_apps/bindings && \
+        export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) && \
+        python3 -m build && \
+        pip3 install --verbose ./dist/pyds-*.whl; \
+    else \
+        cd /tmp && \
+        wget --quiet --show-progress --progress=bar:force:noscroll --no-check-certificate https://github.com/NVIDIA-AI-IOT/deepstream_python_apps/releases/download/v${PYDS_VERSION}/pyds-${PYDS_VERSION}-py3-none-linux_aarch64.whl && \
+        pip3 install --verbose ./pyds-*.whl; \
+    fi
 
 # make sure it loads
 RUN deepstream-app --version && python3 -c 'import pyds'

--- a/packages/multimedia/deepstream/config.py
+++ b/packages/multimedia/deepstream/config.py
@@ -2,22 +2,26 @@
 from jetson_containers import L4T_VERSION, PYTHON_VERSION
 from packaging.version import Version
 
-if L4T_VERSION >= Version('36.2.0'): # JetPack 6.0
+if L4T_VERSION >= Version('36.4.3'): # JetPack 6.2
+    DEEPSTREAM_URL = 'https://api.ngc.nvidia.com/v2/resources/org/nvidia/deepstream/7.1/files?redirect=true&path=deepstream_sdk_v7.1.0_jetson.tbz2'
+    DEEPSTREAM_TAR = 'deepstream_sdk_v7.1.0_jetson.tbz2'
+    PYDS_VERSION = '1.2.0'
+elif L4T_VERSION >= Version('36.2.0'): # JetPack 6.0
     DEEPSTREAM_URL = 'https://api.ngc.nvidia.com/v2/resources/org/nvidia/deepstream/6.4/files?redirect=true&path=deepstream_sdk_v6.4.0_jetson.tbz2'
     DEEPSTREAM_TAR = 'deepstream_sdk_v6.4.0_jetson.tbz2'
-    PYDS_VERSION = 'v1.1.10'
+    PYDS_VERSION = '1.1.10'
 elif L4T_VERSION >= Version('35.2.1'): # JetPack 5.1
     DEEPSTREAM_URL = 'https://api.ngc.nvidia.com/v2/resources/org/nvidia/deepstream/6.3/files?redirect=true&path=deepstream_sdk_v6.3.0_jetson.tbz2'
     DEEPSTREAM_TAR = 'deepstream_sdk_v6.3.0_jetson.tbz2'
-    PYDS_VERSION = 'v1.1.8'
+    PYDS_VERSION = '1.1.8'
 elif L4T_VERSION >= Version('34'):  # JetPack 5.0
     DEEPSTREAM_URL = 'https://nvidia.box.com/shared/static/8jdbxu016wrjz8g5q7dzetj2seksmih9.tbz2'
     DEEPSTREAM_TAR = 'deepstream_sdk_v6.1.0_jetson.tbz2'
-    PYDS_VERSION = 'v1.1.3'
+    PYDS_VERSION = '1.1.3'
 elif L4T_VERSION >= Version('32.6'): # JetPack 4.6
     DEEPSTREAM_URL = 'https://nvidia.box.com/shared/static/uetg0vwukwuqf8109i5coq0rizuflniu.tbz2'
     DEEPSTREAM_TAR = 'deepstream_sdk_v6.0.0_jetson.tbz2'
-    PYDS_VERSION = 'v1.1.1'
+    PYDS_VERSION = '1.1.1'
 else:
     package = None
     

--- a/packages/multimedia/deepstream/upgrade_glib.sh
+++ b/packages/multimedia/deepstream/upgrade_glib.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Migrate glib to newer version (2.76.6), as suggested in Deepstream Installation guide:
+#   https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html#migrate-glib-to-newer-version
+
+set -x
+
+currentGlibVersion=$(pkg-config --modversion glib-2.0)
+dpkg --compare-versions "$currentGlibVersion" "lt" "2.76.6"
+if [[ $? == 0 ]]; then
+  echo "Upgrade the current version of glib-2.0 to 2.76.6"
+  pip3 install meson
+  pip3 install ninja
+  git clone https://github.com/GNOME/glib.git /opt/glib
+  cd /opt/glib
+  git checkout 2.76.6
+  meson build --prefix=/usr
+  ninja -C build/
+  cd build/
+  ninja install
+  pkg-config --modversion glib-2.0
+else
+  echo "Current version of glib-2.0 is >= 2.76.6.  No upgrade needed"
+fi


### PR DESCRIPTION
1) added DeepStream 7.1 information to config.py
2) added script to upgrade glib-2.0 to 2.76.6, as suggested on the official Deepstream Installation Guide.
3) https://github.com/NVIDIA-AI-IOT/deepstream_python_apps no longer support deepstream version below 7.1, and the recommended building method is to use "python3 -m build" instead of cmake.