### PR TITLE
fix sglang

### DIFF
--- a/packages/llm/sglang/Dockerfile
+++ b/packages/llm/sglang/Dockerfile
@@ -12,16 +12,15 @@ FROM ${BASE_IMAGE}
 
 ARG SGLANG_VERSION \
     FLASHINFER_VERSION \
-    CUDA_VERSION \
     CUDAARCHS \
     FORCE_BUILD=off
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TORCH_CUDA_ARCH_LIST="${CUDAARCHS}" \
     MAX_JOBS="$(nproc)" \
-    CUDA_HOME="/usr/local/cuda-${CUDA_VERSION}/" \
+    CUDA_HOME="/usr/local/cuda/" \
     PATH="${CUDA_HOME}/bin:${PATH}" \
-    LD_LIBRARY_PATH="/usr/local/cuda-${CUDA_VERSION}/lib64:${LD_LIBRARY_PATH}"
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 
 RUN apt-get update -y && apt-get install -y libnuma-dev \
     libsndfile1 libsndfile1-dev libprotobuf-dev libsm6 libxext6 libgl1 libavformat58 libavfilter7 && \

--- a/packages/llm/sglang/config.py
+++ b/packages/llm/sglang/config.py
@@ -1,4 +1,4 @@
-from jetson_containers import CUDA_ARCHITECTURES, CUDA_VERSION
+from jetson_containers import CUDA_ARCHITECTURES
 
 def sglang(sglang_version, flashinfer_version, requires=None, default=False):
     pkg = package.copy()
@@ -9,7 +9,6 @@ def sglang(sglang_version, flashinfer_version, requires=None, default=False):
     pkg['name'] = f'sglang:{sglang_version}'
 
     pkg['build_args'] = {
-        'CUDA_VERSION': CUDA_VERSION,
         'CUDAARCHS': ';'.join([str(x) for x in CUDA_ARCHITECTURES]),
         'SGLANG_VERSION': sglang_version,
         'FLASHINFER_VERSION': flashinfer_version,

--- a/packages/multimedia/decord/Dockerfile
+++ b/packages/multimedia/decord/Dockerfile
@@ -2,7 +2,7 @@
 # name: decord
 # group: multimedia
 # config: config.py
-# depends: [cuda, cudnn, numpy, ffmpeg, cmake]
+# depends: [numpy, ffmpeg, cmake]
 # requires: '>=34.1.0'
 # test: test.py
 # notes: https://github.com/dmlc/decord

--- a/packages/multimedia/decord/build.sh
+++ b/packages/multimedia/decord/build.sh
@@ -2,10 +2,11 @@
 set -ex
 
 # Clone the repository if it doesn't exist
-git clone --branch=v${DECORD_VERSION} --depth=1 --recursive https://github.com/dmlc/decord /opt/decord || \
-git clone --depth=1 --recursive https://github.com/dmlc/decord /opt/decord
+git clone --branch=v${DECORD_VERSION} --depth=1 --recursive https://github.com/johnnynunez/decord /opt/decord || \
+git clone --depth=1 --recursive https://github.com/johnnynunez/decord /opt/decord
 
 cd /opt/decord
+mkdir build && cd build
 CUDA_HOME="/usr/local/cuda" \
 NVCC_PATH="${CUDA_HOME}/bin/nvcc" \
 cmake .. -DUSE_CUDA=0 -DCMAKE_BUILD_TYPE=Release

--- a/packages/multimedia/ffmpeg/Dockerfile
+++ b/packages/multimedia/ffmpeg/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
 	    libavfilter-dev \
 	    libavformat-dev \
 	    libavutil-dev \
+	    libavdevice-dev \
 	&& apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This pull request includes several changes to Dockerfiles and configuration files to update dependencies and simplify the build process. The most important changes include removing the CUDA version specification, updating repository URLs, and adding new dependencies.

Updates to CUDA settings:

* [`packages/llm/sglang/Dockerfile`](diffhunk://#diff-f60c0677de93e97f90b2df218ef82ddb930a9baeec7f0f75ad8fc65f8f136bb2L15-R23): Removed `CUDA_VERSION` argument and updated `CUDA_HOME` and `LD_LIBRARY_PATH` to use a generic CUDA path.
* [`packages/llm/sglang/config.py`](diffhunk://#diff-bbed4d6f879f4f01802e1727101cd2e032d425b764582019069980fc9d8bd32dL1-R1): Removed the import and usage of `CUDA_VERSION` in the `sglang` function. [[1]](diffhunk://#diff-bbed4d6f879f4f01802e1727101cd2e032d425b764582019069980fc9d8bd32dL1-R1) [[2]](diffhunk://#diff-bbed4d6f879f4f01802e1727101cd2e032d425b764582019069980fc9d8bd32dL12)

Repository URL updates:

* [`packages/multimedia/decord/build.sh`](diffhunk://#diff-29ed293b424123c07d60f57860c0b470bd07d8c4fc384a183b76be70ede9eff6L5-R9): Updated the repository URL for cloning the `decord` repository to a new GitHub user.

Dependency updates:

* [`packages/multimedia/decord/Dockerfile`](diffhunk://#diff-e06ba62ab1f72121e4a630be7bc7e7fe0e1994c94cc2eeec8f096f0fd554f006L5-R5): Removed `cuda` and `cudnn` from the dependencies list.
* [`packages/multimedia/ffmpeg/Dockerfile`](diffhunk://#diff-363d817bb8aa32759a37bc2eb03b98a0ab20e17e149fc4c7e56292a89ce7e9a6R23): Added `libavdevice-dev` to the list of packages to be installed.