### PR TITLE
fix: use SVT 2.3.0 tag

### DIFF
--- a/packages/multimedia/pyav/Dockerfile
+++ b/packages/multimedia/pyav/Dockerfile
@@ -37,7 +37,7 @@ RUN cd /opt/ffmpeg-${FFMPEG_VERSION}  && \
 # solution mid-february: https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2355#note_2312506245
 # solved https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2387
 RUN cd /opt/ffmpeg-${FFMPEG_VERSION}  && \
-    git -C SVT-AV1 pull 2> /dev/null || git clone --recursive https://gitlab.com/AOMediaCodec/SVT-AV1.git && \
+    git -C SVT-AV1 pull 2> /dev/null || git clone --recursive https://gitlab.com/AOMediaCodec/SVT-AV1.git -b v2.3.0 && \
     mkdir -p SVT-AV1/build
 RUN cd /opt/ffmpeg-${FFMPEG_VERSION}/SVT-AV1/build && \
     PATH="$HOME/bin:$PATH" cmake -G "Unix Makefiles" \


### PR DESCRIPTION
SVT-AV issues in master and 3.0.0: 

https://forums.linuxmint.com/viewtopic.php?p=2580761&sid=d2383e069a7f4298d08e7feac22fb60f#p2580761

checkout to 2.3.0 tag. Built on AGX.

<img width="492" alt="image" src="https://github.com/user-attachments/assets/568bc057-9937-483a-bdef-c3c5fc207659" />
