### PR TITLE
Set torchvision lsb version to >=22.04

### DIFF
--- a/packages/ml/jupyterlab/config.py
+++ b/packages/ml/jupyterlab/config.py
@@ -28,7 +28,7 @@ def jupyterlab(version='latest', requires=None, default=False):
         
     return pkg, myst
     
-default_latest = (Version(LSB_RELEASE) >= Version('24.04'))
+default_latest = (Version(LSB_RELEASE) >= Version('22.04'))
 
 package = [
     jupyterlab('latest', default=default_latest),


### PR DESCRIPTION
With `Version('24.04'))` torchvision package cannot be found anymore when building for `LSB_RELEASE 22.04`

<img width="983" alt="image" src="https://github.com/user-attachments/assets/49b0ee27-1ec5-4288-8335-b783317323fc" />


comparing against >= 22.04 ensures compatibility with 22.04 and 24.04. tested with both. 