### PR TITLE
Fix multiple issues in vila-microservices

### DIFF
--- a/packages/vlm/vila-microservice/docs.md
+++ b/packages/vlm/vila-microservice/docs.md
@@ -255,9 +255,6 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 </code></pre>
 </details>
 
-> [!WARNING]
-> It currently only takes `image/jpeg`.
-
 <details>
 <summary>(Click to expand) More prompt examples</summary>
 <h4>OCR</h4>

--- a/packages/vlm/vila-microservice/docs.md
+++ b/packages/vlm/vila-microservice/docs.md
@@ -198,10 +198,6 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 }'
 ```
 
-> [!WARNING]
-> It currently does not take the online image like `"url": "https://commons.wikimedia.org/wiki/Category:Art#/media/File:Meteorite_Egg.jpg",`.
-
-
 #### RTSP output for preview
 
 Once you use a v4l2 video source, it is regsitered as the input stream.
@@ -316,6 +312,38 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
           "type": "image_url",
           "image_url": {
             "url": "v4l2:///dev/video0"
+          }
+        }
+      ]
+    }
+  ],
+  "max_tokens": 128
+}'
+</code></pre>
+<img src="https://github.com/user-attachments/assets/5d9089ef-76d4-4c54-8472-e433689150ba" alt="Description" width="640">
+
+
+<h4>Base64-encoded PNG</h4>
+<pre><code>
+curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+--header 'Content-Type: application/json' \
+--data '{
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful AI assistant."
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Describe this icon."
+        },
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAYNJREFUOE9j3CEjU/efkbGakYGBjYEE8J+B4Rfj//+tjNtlZX+SqhlmD9iQHbKy/2EC3CoqDNxKSnB3fL5xg4GZi4uBS04OLvbxwgWGn69ewfkoBvBqazMYzJjBwCUvD1ZwKjQUrFmntxfM/3DuHMPF7GyGH0+fYjcAJGq+YQODgJERw59Pnxj2GRgwsAkKMtifOcPAyMjI8Gz9eobL+fkoIYXiAmQDXm7bxnAhIwOs2HLrVgY+XV3SDLhSWsrwdOVKsAEqJSUMynl5pBnw9vhxsDdAgF1cnEHAwIB4A5jY2BiOe3khAoqZmcHx3DmG1wcOEBcG744eZbjd3Y0SWHpTpjD8//uXOANutrQwfDhzBsUAqeBgBmE7O8IGGC1cyHA+KQlsGzJgExFhUK+pYbhcUIA7GkWdnBikwsIYHi1YwPD+xAkUhYLm5gzyiYkMT1evZni9dy/2hCRsY8PAwsfH8PPlS4YPZ8+iGMBvZMTAISHB8OfzZ4a3hw8jDKA8M1GYnQE8m7INTv0HFQAAAABJRU5ErkJggg=="
           }
         }
       ]

--- a/packages/vlm/vila-microservice/src/api_server.py
+++ b/packages/vlm/vila-microservice/src/api_server.py
@@ -189,10 +189,10 @@ class VLMServer(APIServer):
                     else:
                         raise ValueError(f"Unexpected stream_result type: {type(stream_result)}")
 
-                    logging.info(f"Added v4l2 stream with ID: {stream_id}")
+                    logging.info(f"Added custom video stream with ID: {stream_id}")
                 except Exception as e:
-                    logging.error(f"Failed to add v4l2 stream: {str(e)}")
-                    raise HTTPException(status_code=500, detail=f"Failed to add v4l2 stream: {str(e)}")
+                    logging.error(f"Failed to add custom video stream: {str(e)}")
+                    raise HTTPException(status_code=500, detail=f"Failed to add custom video stream: {str(e)}")
 
         # Process the chat completion request
         queue_message = APIMessage(type="query", data=body, id=str(uuid4()), time=time())

--- a/packages/vlm/vila-microservice/src/chat_server.py
+++ b/packages/vlm/vila-microservice/src/chat_server.py
@@ -102,8 +102,9 @@ async def request_alert_completions(body: AlertCompletion):
     chat_history.append("system", body.system_prompt)
 
     #add images
-    for image_string in body.images:
-        image_string = image_string[23:]
+    for image_url in body.images:
+        # Extract base64 data after the comma
+        image_string = image_url.split(',', 1)[1]
         image = decode_image(image_string)
         chat_history.append("user", image=image)
 
@@ -168,7 +169,8 @@ async def request_chat_completion(body: ChatMessages):
                         chat_history.append(role="user", text=content.text)
                         logging.info(f"adding user text: {content.text}")
                     elif content.type == "image_url":
-                        image_string = content.image_url.url[23:]
+                        # Extract base64 data after the comma
+                        image_string = content.image_url.url.split(',', 1)[1]
                         image = decode_image(image_string)
                         chat_history.append(role="user", image=image)
                         logging.info(f"added image")
@@ -223,7 +225,7 @@ if __name__ == "__main__":
                     datefmt='%Y-%m-%d %H:%M:%S')
 
     model_name = config.model.split("/")[-1]
-    if not os.path.exists("/data/models/mlc/dist/models/{model_name}"):
+    if not os.path.exists(f"/data/models/mlc/dist/models/{model_name}"):
         logging.info("Model path not found. Will download and build model. This will take some time.")
         os.makedirs("/data/models/mlc/dist/models", exist_ok=True)
 

--- a/packages/vlm/vila-microservice/src/chat_server.py
+++ b/packages/vlm/vila-microservice/src/chat_server.py
@@ -178,11 +178,16 @@ async def request_chat_completion(body: ChatMessages):
                         chat_history.append(role="user", text=content.text)
                         logging.info(f"adding user text: {content.text}")
                     elif content.type == "image_url":
-                        # Extract base64 data after the comma
-                        image_string = content.image_url.url.split(',', 1)[1]
-                        image = decode_image(image_string)
-                        chat_history.append(role="user", image=image)
-                        logging.info(f"added image")
+                        url = content.image_url.url
+                        if url.startswith("data:image/"):
+                            # Extract base64 data after the comma
+                            image_string = url.split(',', 1)[1]
+                            image = decode_image(image_string)
+                            chat_history.append(role="user", image=image)
+                            logging.info(f"added image")
+                        else:
+                            # Skip non-base64 URLs (they should have been handled by the API server)
+                            logging.info(f"Skipping non-base64 URL: {url[:10]}...")
 
             else:
                 logging.info(f"Message is invalid type: {type(message.content)}")

--- a/packages/vlm/vila-microservice/src/chat_server.py
+++ b/packages/vlm/vila-microservice/src/chat_server.py
@@ -35,12 +35,21 @@ from mmj_utils.api_schemas import *
 
 def decode_image(base64_string):
     start = time()
+
     # Decode the base64 string
     image_data = base64.b64decode(base64_string)
+
     # Convert binary data to an image
     image = Image.open(io.BytesIO(image_data))
+
+    # Convert RGBA to RGB (fix for torchvision normalize issue)
+    if image.mode == "RGBA":
+        logging.warning("Image is RGBA, converting to RGB...")
+        image = image.convert("RGB")
+
     end = time()
     logging.info(f"Image decoding time: {end-start} seconds")
+
     return image
 
 model = None

--- a/packages/vlm/vila-microservice/src/main.py
+++ b/packages/vlm/vila-microservice/src/main.py
@@ -148,17 +148,13 @@ while True:
 
                 #cannot add stream
                 if v_input.connected:
-                    cmd_resp[message.id] = {"success": False, "message": "Stream Maximum reached. Remove a stream first to add another."}
+                    logging.warn("A registered stream exists. Over-writing.")
 
-                #adds stream
-                else:
-                    #add new stream
-                    rtsp_link = message.data["stream_url"]
-                    v_input.connect_stream(rtsp_link, camera_id=message.data["stream_id"])
-                    if not v_input.connected:
-                        cmd_resp[message.id] = {"success": False, "message": "Failed to add stream."}
-                    else:
-                        cmd_resp[message.id] = {"success": True, "message": "Successfully connected to stream"}
+                #add/over-write new stream
+                stream_link = message.data["stream_url"]
+                v_input.connect_stream(stream_link, camera_id=message.data["stream_id"])
+
+                cmd_resp[message.id] = {"success": True, "message": "Successfully connected to stream"}
 
 
             elif message.type == "stream_remove":

--- a/packages/vlm/vila-microservice/src/mmj_utils_overlay/mmj_utils/api_schemas.py
+++ b/packages/vlm/vila-microservice/src/mmj_utils_overlay/mmj_utils/api_schemas.py
@@ -20,7 +20,7 @@ from typing import Optional, Union, Dict, List, Literal
 class AlertCompletion(BaseModel):
     """Schema for batch alert completions"""
     system_prompt: Optional[constr(min_length=0, max_length=20000)]
-    images: conlist(item_type=constr(min_length=1, max_length=5000000, pattern=r'^data:image/jpeg;base64,.*'), min_length=1)
+    images: conlist(item_type=constr(min_length=1, max_length=5000000, pattern=r'^data:image/[a-zA-Z]+;base64,.*'), min_length=1)
     user_prompts: conlist(item_type=constr(min_length=0, max_length=20000), min_length=1)
     max_tokens: Optional[conint(gt=0, le=4096)] = 128
     min_tokens: Optional[conint(gt=0, le=4096)] = 1
@@ -53,7 +53,11 @@ class Response(BaseModel):
 
 class ChatContentImageOptions(BaseModel):
     """Schema for b64 encoded image content or video device URL"""
-    url: constr(min_length=0, max_length=5000000, pattern=r'^(data:image/jpeg;base64,.*|v4l2:///.*)') #5MB max b64 string or v4l2 URL
+    url: constr(
+        min_length=0,
+        max_length=5000000,
+        pattern=r'^(data:image/[a-zA-Z]+;base64,.*|csi://.*|v4l2://.*|webrtc://.*|rtp://.*|rtsp://.*|file://.*)'
+    ) #5MB max b64 string or custom video source
 
 class ChatContentStreamOptions(BaseModel):
     """Schema for stream content ID"""

--- a/packages/vlm/vila-microservice/src/mmj_utils_overlay/mmj_utils/vlm.py
+++ b/packages/vlm/vila-microservice/src/mmj_utils_overlay/mmj_utils/vlm.py
@@ -90,16 +90,17 @@ class VLM:
                             insert_counter += 1
                         del chat_completion.messages[m].content[c]
 
-                    # Handle v4l2 URLs
+                    # Handle custom video sources
                     elif content.type == "image_url" and hasattr(content, "image_url"):
                         url = content.image_url.url
-                        # Check if it's a v4l2 URL
-                        if url.startswith("v4l2:///"):
+                        # Check if it's a custom video source
+                        CUSTOM_VIDEO_SCHEMES = ("csi://", "v4l2://", "webrtc://", "rtp://", "rtsp://", "file://")
+                        if any(url.startswith(scheme) for scheme in CUSTOM_VIDEO_SCHEMES):
                             if images is None or image_counter >= len(images):
-                                logging.info("Not enough images were supplied for v4l2 URL replacement.")
+                                logging.info("Not enough images were supplied for custom video source replacement.")
                                 continue
 
-                            # Replace v4l2 URL with base64 encoded image
+                            # Replace custom video source URL with base64 encoded image
                             image = images[image_counter]
                             image = self._encode_image(image)
                             image_string = f"data:image/jpeg;base64,{image}"


### PR DESCRIPTION
- Enable all the video source (that's supported by `jetson_utils`)
- Enable online (http) image
- Handle base64 image type other than jpeg (jpg/png/webp)
    - Handle RGBA type image
- Allow over-writing a registered stream by throwing another request with a different video source
