### PR TITLE
Vila microservice to use same port (9000) and api scheme (starting from /v1)

### DIFF
--- a/packages/vlm/vila-microservice/config/main_config.json
+++ b/packages/vlm/vila-microservice/config/main_config.json
@@ -1,5 +1,5 @@
 {
-    "api_server_port": 5010,
+    "api_server_port": 9000,
     "prometheus_port": 5012,
     "websocket_server_port":5016,
     "stream_output": "rtsp://0.0.0.0:5011/out",

--- a/packages/vlm/vila-microservice/docs.md
+++ b/packages/vlm/vila-microservice/docs.md
@@ -152,9 +152,9 @@ Once done, you will see an output like the following.
 
 | Method | API Endpoint | Description |
 | ------ | ------------ | ----------- |
-| `GET`  | `/api/v1/models` | return the VLM name in list |
-| `POST` | `/api/v1/chat/completion` | Chat with the VLM using OpenAI style chat completions. Supports referencing added streams in the prompts. |
-| `POST` | `/api/v1/alerts`          | Set an alert prompt the VLM will evaluate continuously on the input live stream. Can be used to trigger notifications when alert states are true. |
+| `GET`  | `/v1/models` | return the VLM name in list |
+| `POST` | `/v1/chat/completion` | Chat with the VLM using OpenAI style chat completions. Supports referencing added streams in the prompts. |
+| `POST` | `/v1/alerts`          | Set an alert prompt the VLM will evaluate continuously on the input live stream. Can be used to trigger notifications when alert states are true. |
 
 You can check the documentation of (the original) VLM Service of Jetson Platform Services as a reference.
 https://docs.nvidia.com/jetson/jps/inference-services/vlm.html#overview
@@ -170,7 +170,7 @@ You can specify the local v4l2 device path after `v4l2://` and put it in the `im
 The v4l2 device is registered as the input video stream and VLM processes the latest frame of the video stream.
 
 ```bash
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [
@@ -226,7 +226,7 @@ You can also embed the image and pass that through API.
 <details>
   <summary>(Click to expand) curl command with base64 encoded image</summary>
 <pre><code>
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [
@@ -259,7 +259,7 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 <summary>(Click to expand) More prompt examples</summary>
 <h4>OCR</h4>
 <pre><code>
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [
@@ -290,7 +290,7 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 
 <h4>Counting</h4>
 <pre><code>
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [
@@ -322,7 +322,7 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 
 <h4>Base64-encoded PNG</h4>
 <pre><code>
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [
@@ -352,7 +352,7 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 
 <h4>Online image</h4>
 <pre><code>
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [{
@@ -373,7 +373,7 @@ curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
 
 <h4>CSI camera</h4>
 <pre><code>
-curl --location --request POST 'http://0.0.0.0:5010/api/v1/chat/completions' \
+curl --location --request POST 'http://0.0.0.0:9000/v1/chat/completions' \
 --header 'Content-Type: application/json' \
 --data '{
   "messages": [

--- a/packages/vlm/vila-microservice/src/api_server.py
+++ b/packages/vlm/vila-microservice/src/api_server.py
@@ -45,9 +45,9 @@ class VLMServer(APIServer):
 
         self.max_alerts = max_alerts
 
-        self.app.post("/api/v1/alerts")(self.alerts)
-        self.app.post("/api/v1/chat/completions")(self.chat_completion)
-        self.app.get("/api/v1/models")(self.get_model_name)
+        self.app.post("/v1/alerts")(self.alerts)
+        self.app.post("/v1/chat/completions")(self.chat_completion)
+        self.app.get("/v1/models")(self.get_model_name)
 
     def get_model_name(self):
         """

--- a/packages/vlm/vila-microservice/src/ws_server.py
+++ b/packages/vlm/vila-microservice/src/ws_server.py
@@ -13,32 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio 
-from dataclasses import dataclass 
-from time import sleep 
+import asyncio
+from dataclasses import dataclass
+from time import sleep
 from threading import Thread
-import logging 
-from datetime import datetime 
+import logging
+from datetime import datetime
 
-from fastapi import FastAPI, WebSocket 
+from fastapi import FastAPI, WebSocket
 from pydantic import BaseModel
-import uvicorn 
+import uvicorn
 
 class Alert(BaseModel):
-    title: str 
-    description: str 
-    alert_id: str 
-    type: str 
-    rule_string: str 
-    timestamp: str 
+    title: str
+    description: str
+    alert_id: str
+    type: str
+    rule_string: str
+    timestamp: str
     stream_id: str = ""
- 
+
 class WebSocketServer:
 
     def __init__(self, port=5016):
-        self.port = port 
+        self.port = port
         self.app = FastAPI()
-        self.app.websocket("/api/v1/alerts/ws")(self.websocket_endpoint)
+        self.app.websocket("/v1/alerts/ws")(self.websocket_endpoint)
 
         self.active_connections = {}
 
@@ -58,12 +58,12 @@ class WebSocketServer:
                 logging.debug("received alert")
 
                 alert_obj = Alert(
-                                    title = f"VLM Alert Triggered", 
+                                    title = f"VLM Alert Triggered",
                                     description = f"The VLM has determined the alert rule: {alert['alert_str']} is True!",
                                     alert_id = str(alert["alert_id"]),
-                                    type = "vlm_alert", 
-                                    rule_string = alert["alert_str"], 
-                                    timestamp = str(full_timestamp), 
+                                    type = "vlm_alert",
+                                    rule_string = alert["alert_str"],
+                                    timestamp = str(full_timestamp),
                                     stream_id = alert["stream_id"]
                                 )
 
@@ -73,12 +73,11 @@ class WebSocketServer:
         except Exception as e:
             logging.debug(e)
             del self.active_connections[websocket]
-        
+
     def _start_server(self):
         uvicorn.run(self.app, host="0.0.0.0", port=self.port)
 
     def start_server(self):
         self.server_thread = Thread(target=self._start_server, daemon=True, name="REST Server")
-        self.server_thread.start() 
+        self.server_thread.start()
 
-        


### PR DESCRIPTION
Vila microservice to use 
- port (9000) , as oppose to `5010`
- Public facing  API scheme starting from just `/v1`,  as oppose to starting from `/api/v1` 