### PR TITLE
Fix faiss build v1.10.0

### DIFF
--- a/packages/vectordb/faiss/build.sh
+++ b/packages/vectordb/faiss/build.sh
@@ -27,6 +27,7 @@ cmake \
   -DPYTHON_EXECUTABLE=/usr/bin/python3 \
   -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} \
   -DCMAKE_INSTALL_PREFIX=${install_dir} \
+  -DBUILD_SHARED_LIBS=ON \
   ../
   
 make -j$(nproc) faiss

--- a/packages/vectordb/faiss/config.py
+++ b/packages/vectordb/faiss/config.py
@@ -30,8 +30,9 @@ def faiss(version, branch=None, requires=None, default=False):
     
 package = [
     faiss('1.7.3'),
-    faiss('1.7.4', default=False),
+    faiss('1.7.4'),
+    faiss('1.8.0'),
+    faiss('1.9.0'),
     faiss('1.10.0', default=True),
-    #faiss('v1.8.0'),  # encounters type_info build error sometime after be12427 (12/12/2023)
     #faiss('be12427', default=True),  # known good build on JP5/JP6 from 12/12/2023
 ]

--- a/packages/vectordb/faiss/install.sh
+++ b/packages/vectordb/faiss/install.sh
@@ -15,7 +15,6 @@ if [ "$FORCE_BUILD" == "on" ]; then
 	exit 1
 fi
 
-pip3 install setuptools==75.8.2
 tarpack install faiss-${FAISS_VERSION}
 pip3 install faiss==${FAISS_VERSION}
 

--- a/packages/vectordb/faiss/install.sh
+++ b/packages/vectordb/faiss/install.sh
@@ -5,6 +5,7 @@ set -ex
 apt-get update
 apt-get install -y --no-install-recommends \
 	  libopenblas-dev \
+	  libgflags-dev \
 	  swig
 rm -rf /var/lib/apt/lists/*
 apt-get clean
@@ -14,6 +15,7 @@ if [ "$FORCE_BUILD" == "on" ]; then
 	exit 1
 fi
 
+pip3 install setuptools==75.8.2
 tarpack install faiss-${FAISS_VERSION}
 pip3 install faiss==${FAISS_VERSION}
 


### PR DESCRIPTION
Fixes https://github.com/dusty-nv/jetson-containers/issues/955
Also fixed the `type_info` build error that was encountered in v1.8.0. Versions 1.7.4 to 1.10.0 were successfully build.
Note, a problem occurred with the import of the distutils package inside the faiss package. Setuptools was updated to fix this issue. The setuptools version should either be <= 75.8.2 or >= 77.0.2. See https://github.com/dusty-nv/jetson-containers/issues/955