### PR TITLE
fix: clean /tmp/cudnn directory before creating it to prevent leftover file

### DIFF
--- a/packages/cuda/cudnn/Dockerfile
+++ b/packages/cuda/cudnn/Dockerfile
@@ -17,7 +17,7 @@ RUN ls /etc/apt/sources.list.d/ && \
     apt-cache search cudnn
 
 RUN echo "Downloading ${CUDNN_DEB}" && \
-    mkdir /tmp/cudnn && cd /tmp/cudnn && \
+    rm -rf /tmp/cudnn && mkdir /tmp/cudnn && cd /tmp/cudnn && \
     wget --quiet --show-progress --progress=bar:force:noscroll ${CUDNN_URL} && \
     dpkg -i *.deb && \
     cp /var/cudnn-local-tegra-repo-*/cudnn-local-tegra-*-keyring.gpg /usr/share/keyrings/ && \


### PR DESCRIPTION
mkdir /tmp/cudnn will fail if /tmp/cudnn already exists. This ensure we clean up old temporary files.


Repo:

Run this and see it fails
```
jetson-containers build --base=dustynv/deepstream:r36.2.0 --name=edge-jc pytorch opencv tensorrt flash-attention bitsandbytes cuda-python torchaudio torchvision
```


