### PR TITLE
Make it clear when it fails downloading OpenCV-4.x.0-aarch64.tar.gz

### DIFF
--- a/packages/opencv/install_deb.sh
+++ b/packages/opencv/install_deb.sh
@@ -37,12 +37,20 @@ apt-get purge -y '.*opencv.*' || echo "previous OpenCV installation not found"
 # download and extract the deb packages
 mkdir opencv
 cd opencv
-wget --quiet --show-progress --progress=bar:force:noscroll --no-check-certificate ${OPENCV_URL} -O ${OPENCV_DEB}
-tar -xzvf ${OPENCV_DEB}
+
+echo "Downloading OpenCV archive from ${OPENCV_URL}..."
+if ! wget --quiet --show-progress --progress=bar:force:noscroll --no-check-certificate "${OPENCV_URL}" -O "${OPENCV_DEB}"; then
+    echo "❌ ERROR: Failed to download OpenCV archive from ${OPENCV_URL}"
+    exit 1
+fi
+
+echo "✅ Successfully downloaded ${OPENCV_DEB}"
+echo "Extracting ${OPENCV_DEB}..."
+tar -xzvf "${OPENCV_DEB}"
 
 # install the packages and their dependencies
 dpkg -i --force-depends *.deb
-apt-get update 
+apt-get update
 apt-get install -y -f --no-install-recommends
 dpkg -i *.deb
 rm -rf /var/lib/apt/lists/*
@@ -63,18 +71,18 @@ if [ $ARCH = "aarch64" ]; then
 		echo "$local_include_path already exists, replacing..."
 		rm -rf $local_include_path
 	fi
-	
+
 	if [ -d "$local_python_path" ]; then
 		echo "$local_python_path already exists, replacing..."
 		rm -rf $local_python_path
 	fi
-	
+
 	ln -s /usr/include/opencv4 $local_include_path
 	ln -s /usr/lib/python${PYTHON3_VERSION}/dist-packages/cv2 $local_python_path
-	
+
 elif [ $ARCH = "x86_64" ]; then
 	opencv_conda_path="/opt/conda/lib/python${PYTHON3_VERSION}/site-packages/cv2"
-	
+
 	if [ -d "$opencv_conda_path" ]; then
 		echo "$opencv_conda_path already exists, replacing..."
 		rm -rf $opencv_conda_path


### PR DESCRIPTION
It was failing to download `https://apt.jetson-ai-lab.dev/jp6/cu126/OpenCV-4.11.0.tar.gz` but it was masked out with `wget --quiet` so I made it clear to show it failed to download (thus went into building from source).