### PR TITLE
Update ros2_build.sh to fix issue with building on cmake > 4.0.0

### DIFF
--- a/packages/ros/ros2_build.sh
+++ b/packages/ros/ros2_build.sh
@@ -60,7 +60,7 @@ pip3 install --upgrade \
 # https://github.com/dusty-nv/jetson-containers/issues/216			  
 python3 -m pip install --upgrade pip
 pip3 install scikit-build
-pip3 install --upgrade cmake
+pip3 install --upgrade "cmake<4.0.0"
 cmake --version
 which cmake
 


### PR DESCRIPTION
Build fails (when building fastcdr) when trying to use cmake > 4.0.0, due to compatability with cmake 3.5 being removed. This fix is a fast way to remedy.