### PR TITLE
Update Dockerfile.ros2 COPY command to fix "exec error"

### DIFF
--- a/packages/ros/Dockerfile.ros2
+++ b/packages/ros/Dockerfile.ros2
@@ -44,7 +44,8 @@ RUN if [ $(lsb_release -rs) = '24.04' ]; then \
 #ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 # commands will be appended/run by the entrypoint which sources the ROS environment
-COPY ros_entrypoint.sh ros2_install.sh /
+COPY ros_entrypoint.sh /
+COPY ros2_install.sh /
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
When building ros2, an exec error was occuring when the container was trying to run the ENTRYPOINT command, and for some reason this was tracked down to the ros_entrypoint.sh file being empty inside the container.

Changing the single COPY command to two commands (for ros_entrypoint and ros2_install) fixed it. I am still not sure why..