### PR TITLE
Bugfix/#1016 resolve `smart-home` packages network issues

### DIFF
--- a/packages/smart-home/wyoming/assist-microphone/build.sh
+++ b/packages/smart-home/wyoming/assist-microphone/build.sh
@@ -11,19 +11,16 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 
 pip3 install -U \
+   build \
    setuptools \
    wheel \
    webrtc-noise-gain==1.2.3 \
    pysilero-vad==1.0.0
 
-echo "assist_microphone: ${SATELLITE_VERSION} (branch: ${SATELLITE_BRANCH})"
-
 git clone --branch=${SATELLITE_BRANCH} https://github.com/rhasspy/wyoming-satellite /tmp/wyoming_satellite
 cd /tmp/wyoming_satellite
 
-sed -i "s|version=\"[^\"]*\"|version=\"${SATELLITE_VERSION}\"|" setup.py
-
-python3 setup.py sdist bdist_wheel --verbose --dist-dir $PIP_WHEEL_DIR
+python3 -m build --wheel --sdist --outdir $PIP_WHEEL_DIR
 
 cd /
 rm -rf /tmp/wyoming_satellite
@@ -31,7 +28,6 @@ rm -rf /tmp/wyoming_satellite
 pip3 install $PIP_WHEEL_DIR/wyoming_satellite*.whl
 
 pip3 show wyoming_satellite
-python3 -c 'import wyoming_satellite; print(wyoming_satellite.__version__);'
 
 twine upload --skip-existing --verbose $PIP_WHEEL_DIR/wyoming_satellite*.whl || echo "failed to upload wheel to ${TWINE_REPOSITORY_URL}"
 

--- a/packages/smart-home/wyoming/assist-microphone/config.py
+++ b/packages/smart-home/wyoming/assist-microphone/config.py
@@ -1,18 +1,17 @@
-from jetson_containers import handle_text_request
+from jetson_containers import github_latest_tag
 
 
-def create_package(version, branch=None, default=False) -> list:
+def create_package(version, default=False) -> list:
     pkg = package.copy()
+    wanted_version = github_latest_tag('rhasspy/wyoming-satellite') if version == 'latest' else version
 
-    if not branch:
-        branch = f'v{version}'
+    if wanted_version.startswith("v"):
+        wanted_version = wanted_version[1:]
 
-    wanted_version = handle_text_request(f'https://raw.githubusercontent.com/rhasspy/wyoming-satellite/{branch}/wyoming_satellite/VERSION')
     pkg['name'] = f'wyoming-assist-microphone:{wanted_version}'
-
     pkg['build_args'] = {
         'SATELLITE_VERSION': wanted_version,
-        'SATELLITE_BRANCH': branch
+        'SATELLITE_BRANCH': f"v{wanted_version}",
     }
 
     builder = pkg.copy()
@@ -26,7 +25,5 @@ def create_package(version, branch=None, default=False) -> list:
     return pkg, builder
 
 package = [
-    create_package("1.4.0", branch="master", default=True),
-    create_package("1.3.0", branch="master", default=False),
-    create_package("1.2.0"),
+    create_package("latest", default=True),
 ]


### PR DESCRIPTION
This `PR` is resolving the https://github.com/dusty-nv/jetson-containers/issues/1016 issue. The `wyoming-assist-microphone` package build logic was adjusted to the upstream changes:

```log
jetson-containers build wyoming-assist-microphone

Namespace(packages=['wyoming-assist-microphone'], name='', base='', multiple=False, build_flags='', build_args='', use_proxy=False, package_dirs=[''], list_packages=False, show_packages=False, skip_packages=[''], skip_errors=False, skip_tests=[''], test_only=[''], simulate=False, push='', logs='', verbose=False, version=False, no_github_api=False)

┌──────────────┬─────────┬─────────────────┬───────┐
│ L4T_VERSION  │ 36.4.0  │ JETPACK_VERSION │ 6.1   │
├──────────────┼─────────┼─────────────────┼───────┤
│ CUDA_VERSION │ 12.6    │ PYTHON_VERSION  │ 3.1   │
├──────────────┼─────────┼─────────────────┼───────┤
│ SYSTEM_ARCH  │ aarch64 │ LSB_RELEASE     │ 22.04 │
└──────────────┴─────────┴─────────────────┴───────┘

$ jetson-containers wyoming-assist-microphone

[info] GET https://api.github.com/repos/home-assistant/docker-base/tags (attempt 1)
[info] GET https://api.github.com/repos/home-assistant-libs/psutil-home-assistant/tags (attempt 1)
[info] GET https://pypi.org/pypi/transformers/json (attempt 1)
[info] GET https://version.home-assistant.io/stable.json (attempt 1)
[info] GET https://api.github.com/repos/closeio/ciso8601/tags (attempt 1)
[info] GET https://api.github.com/repos/rhasspy/wyoming-satellite/tags (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-faster-whisper/v2.4.0/wyoming_faster_whisper/VERSION (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-openwakeword/master/wyoming_openwakeword/VERSION (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-piper/v1.5.2/wyoming_piper/VERSION (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-faster-whisper/v2.3.0/wyoming_faster_whisper/VERSION (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-openwakeword/v1.10.0/wyoming_openwakeword/VERSION (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-piper/v1.5.0/wyoming_piper/VERSION (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/home-assistant/docker-base/2025.02.0/ubuntu/build.yaml (attempt 1)
[info] GET https://api.github.com/repos/huggingface/transformers/tags (attempt 1)
[INFO] Fetching: https://raw.githubusercontent.com/rhasspy/wyoming-faster-whisper/v2.2.0/wyoming_faster_whisper/VERSION (attempt 1)
-- Building containers  ['build-essential', 'homeassistant-base', 'pip_cache', 'python:3.11', 'wyoming-assist-microphone']
```