### PR TITLE
fix: improve OpenCV test image download with retry logic and fallback

### DIFF
--- a/packages/opencv/test.py
+++ b/packages/opencv/test.py
@@ -4,6 +4,8 @@ print('testing OpenCV...')
 import cv2
 import sys
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 print('OpenCV version:', str(cv2.__version__))
 print(cv2.getBuildInformation())
@@ -15,15 +17,40 @@ except Exception as ex:
     print('OpenCV was not built with CUDA')
     raise ex
 
-# download test image    
-img_url = 'https://raw.githubusercontent.com/dusty-nv/jetson-containers/59f840abbb99f22914a7b2471da829b3dd56122e/test/data/test_0.jpg'
+# download test image with retry logic
+img_url = 'https://raw.githubusercontent.com/opencv/opencv/4.x/samples/data/lena.jpg'  # More reliable URL
 img_path = '/tmp/test_0.jpg'
 
-request = requests.get(img_url, allow_redirects=True)
-open(img_path, 'wb').write(request.content)
+# Configure retry strategy
+retry_strategy = Retry(
+    total=3,  # number of retries
+    backoff_factor=1,  # wait 1, 2, 4 seconds between retries
+    status_forcelist=[500, 502, 503, 504]  # HTTP status codes to retry on
+)
+adapter = HTTPAdapter(max_retries=retry_strategy)
+http = requests.Session()
+http.mount("https://", adapter)
+http.mount("http://", adapter)
+
+try:
+    response = http.get(img_url, allow_redirects=True, timeout=10)
+    response.raise_for_status()  # Raise an exception for bad status codes
+    with open(img_path, 'wb') as f:
+        f.write(response.content)
+    print(f'Successfully downloaded test image from {img_url}')
+except Exception as e:
+    print(f'Error downloading test image: {e}')
+    print('Using a local test image instead...')
+    # Use a simple test image creation as fallback
+    import numpy as np
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    cv2.imwrite(img_path, img)
+    print('Created a local test image')
 
 # load image
 img_cpu = cv2.imread(img_path)
+if img_cpu is None:
+    raise Exception(f'Failed to load test image from {img_path}')
 print(f'loaded test image from {img_path}  {img_cpu.shape}  {img_cpu.dtype}')
 
 # test GPU processing


### PR DESCRIPTION
## Description
This PR improves the OpenCV test image download mechanism to make it more reliable by:
- Using OpenCV's official sample image as the test image source
- Adding retry logic with exponential backoff
- Implementing a fallback mechanism to create a local test image if download fails
- Adding proper error handling and timeout
- Providing better error messages

## Changes
- Changed test image URL to use OpenCV's official sample image
- Added retry strategy with exponential backoff (3 retries, 1s, 2s, 4s intervals)
- Added fallback to create a local test image if download fails
- Added 10-second timeout to prevent hanging
- Added better error messages and status reporting

## Testing
The changes have been tested on:
- [x] Build with
    - [x] `opencv:4.11`
    - [x] `opencv`
    - [x] `lerobot`

## Related Issues
Fixes intermittent test failures due to network connectivity issues during OpenCV package build.