### PR TITLE
Fix missing default for llama_cpp

### DIFF
--- a/packages/llm/llama_cpp/config.py
+++ b/packages/llm/llama_cpp/config.py
@@ -42,5 +42,5 @@ package = [
     llama_cpp('0.3.5'),
     llama_cpp('0.3.6'),
     llama_cpp('0.3.7'),
-    llama_cpp('0.3.8'),
+    llama_cpp('0.3.8', default=True),
 ]


### PR DESCRIPTION
I also ran into the issue here:
https://github.com/dusty-nv/jetson-containers/issues/968

So, I've opened up this PR to add in the missing default parameter so that autotag building works.