### PR TITLE
Fix the `file: not found` issue by installing file command

### DIFF
--- a/packages/cuda/cudnn/Dockerfile
+++ b/packages/cuda/cudnn/Dockerfile
@@ -24,12 +24,12 @@ RUN echo "Downloading ${CUDNN_DEB}" && \
     apt-get update && \
     apt-cache search cudnn && \
     apt list --installed | grep 'cuda\|cudnn\|cublas' && \
-    apt-get install -y --no-install-recommends ${CUDNN_PACKAGES} && \
+    apt-get install -y --no-install-recommends ${CUDNN_PACKAGES} file && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean && \
     dpkg --list | grep cudnn && \
     dpkg -P ${CUDNN_DEB} && \
     rm -rf /tmp/cudnn
-    
+
 RUN cd /usr/src/cudnn_samples_v*/conv_sample/ && \
     make -j$(nproc)


### PR DESCRIPTION

While this doesn't break the build, it produces unnecessary error output. This PR installs the `file` utility to suppress that error and ensure a cleaner build log.

## Changes

- Install `file` in the `cudnn` Dockerfile to support the Makefile's architecture check

## Notes

This change helps avoid misleading errors in the logs and makes the build output cleaner and easier to debug.

## Issue

https://github.com/dusty-nv/jetson-containers/issues/1059