### PR TITLE
Show elapsed time in the progress bar

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -212,7 +212,7 @@ def build_container(
             # Calculate spaces needed to align time to right edge
             status_text = f"[{idx+1}/{len(packages)}] Building {package} ({container_name})"
             current_time = datetime.datetime.now().strftime("%H:%M:%S")
-            time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+            time_text = f"{idx} stages completed in {format_time_minutes(timer.get_elapsed())} at {current_time}"
             spaces_needed = terminal.columns - len(status_text) - len(time_text)
             if spaces_needed > 0:
                 status_text = status_text + ' ' * spaces_needed
@@ -235,7 +235,7 @@ def build_container(
             if len(test_only) == 0 or package in test_only:
                 status_text = f"[{idx+1}/{len(packages)}] Testing {package} ({container_name})"
                 current_time = datetime.datetime.now().strftime("%H:%M:%S")
-                time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+                time_text = f"{idx} stages completed in {format_time_minutes(timer.get_elapsed())} at {current_time}"
                 spaces_needed = terminal.columns - len(status_text) - len(time_text)
                 if spaces_needed > 0:
                     status_text = status_text + ' ' * spaces_needed

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -41,6 +41,15 @@ def format_time(seconds):
     seconds = int(seconds % 60)
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
+def format_time_minutes(seconds):
+    """Format time in mm:ss format, without padding for minutes over 99"""
+    minutes = int(seconds // 60)
+    seconds = int(seconds % 60)
+    if minutes < 100:
+        return f"{minutes:02d}m{seconds:02d}s"
+    else:
+        return f"{minutes}m{seconds:02d}s"
+
 class BuildTimer:
     def __init__(self):
         self.start_time = time.time()
@@ -203,7 +212,7 @@ def build_container(
             # Calculate spaces needed to align time to right edge
             status_text = f"[{idx+1}/{len(packages)}] Building {package} ({container_name})"
             current_time = datetime.datetime.now().strftime("%H:%M:%S")
-            time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+            time_text = f"{idx} stages completed in {format_time_minutes(timer.get_elapsed())} at {current_time}"
             spaces_needed = terminal.columns - len(status_text) - len(time_text)
             if spaces_needed > 0:
                 status_text = status_text + ' ' * spaces_needed

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -255,7 +255,7 @@ def build_container(
             if len(test_only) == 0 or package in test_only:
                 status_text = f"[{idx+1}/{len(packages)}] Testing {package} ({name})"
                 current_time = datetime.datetime.now().strftime("%H:%M:%S")
-                time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+                time_text = f"{idx} stages completed in {format_time_minutes(timer.get_elapsed())} at {current_time}"
                 spaces_needed = terminal.columns - len(status_text) - len(time_text)
                 if spaces_needed > 0:
                     status_text = status_text + ' ' * spaces_needed

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -10,18 +10,20 @@ import logging
 import traceback
 import subprocess
 import dockerhub_api
+import datetime
+from typing import List, Dict, Any, Union
 
 from packaging.version import Version
 
 from .packages import find_package, find_packages, resolve_dependencies, validate_dict
 
 from .utils import (
-    split_container_name, query_yes_no, needs_sudo, sudo_prefix, 
+    split_container_name, query_yes_no, needs_sudo, sudo_prefix,
     get_env, get_dir, get_repo_dir
 )
 
 from .logging import (
-    get_log_dir, log_status, log_success, log_status, log_warning, log_debug, 
+    get_log_dir, log_status, log_success, log_status, log_warning, log_debug,
     log_block, log_info, print_log, pprint_debug, colorize, LogConfig
 )
 
@@ -30,9 +32,29 @@ from .l4t_version import (
   get_l4t_base, get_cuda_arch, get_cuda_version, get_jetpack_version, get_lsb_release
 )
 
-
 _NEWLINE_=" \\\n"  # used when building command strings
 
+def format_time(seconds):
+    """Format time in hh:mm:ss format"""
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    seconds = int(seconds % 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+class BuildTimer:
+    def __init__(self):
+        self.start_time = time.time()
+        self.stage_start = time.time()
+        self.current_stage = 0
+
+    def get_elapsed(self):
+        """Get total elapsed time"""
+        return time.time() - self.start_time
+
+    def next_stage(self):
+        """Move to next stage and reset stage timer"""
+        self.stage_start = time.time()
+        self.current_stage += 1
 
 def build_container(
         name: str='', packages: list=[], base: str=get_l4t_base(),
@@ -125,16 +147,22 @@ def build_container(
             log_info(f"{i}...")
             time.sleep(1)
 
+    # Initialize status bar and clear screen
+    terminal = os.get_terminal_size()
+    print(f'\033[1;{terminal.lines-1}r\033[?6l\033[2J\033[H]', end='', flush=True)
+    LogConfig.status = True
+
+    # Initialize build timer
+    timer = BuildTimer()
+
     # build chain of all packages
     for idx, package in enumerate(packages):
+        pkg = find_package(package)
         # tag this build stage with the sub-package
         container_name = f"{name}-{package.replace(':','_')}"
 
         # generate the logging file (without the extension)
         log_file = os.path.join(get_log_dir('build'), container_name.replace('/','_')).replace(':','_')
-
-        # build next intermediate container
-        pkg = find_package(package)
 
         if 'dockerfile' in pkg:
             cmd = f"{sudo_prefix()}DOCKER_BUILDKIT=0 docker build --network=host" + _NEWLINE_
@@ -171,7 +199,15 @@ def build_container(
             cmd += '   ' + pkg['path']
 
             log_block(f"<b>> BUILDING  {container_name}</b>", f"<b>{cmd}</b>")
-            log_status(f"[{idx+1}/{len(packages)}] <b>Building {package}</b> ({container_name})")
+
+            # Calculate spaces needed to align time to right edge
+            status_text = f"[{idx+1}/{len(packages)}] Building {package} ({container_name})"
+            current_time = datetime.datetime.now().strftime("%H:%M:%S")
+            time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+            spaces_needed = terminal.columns - len(status_text) - len(time_text)
+            if spaces_needed > 0:
+                status_text = status_text + ' ' * spaces_needed
+            log_status(f"{status_text}{time_text}")
 
             cmd += _NEWLINE_ + f"2>&1 | tee {log_file + '.txt'}" + "; exit ${PIPESTATUS[0]}"  # non-tee version:  https://stackoverflow.com/a/34604684
 
@@ -188,11 +224,18 @@ def build_container(
         # run tests on the intermediate container
         if package not in skip_tests and 'intermediate' not in skip_tests and 'all' not in skip_tests:
             if len(test_only) == 0 or package in test_only:
-                log_status(f"[{idx+1}/{len(packages)}] <b>Testing {package}</b> ({container_name})")
+                status_text = f"[{idx+1}/{len(packages)}] Testing {package} ({container_name})"
+                current_time = datetime.datetime.now().strftime("%H:%M:%S")
+                time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+                spaces_needed = terminal.columns - len(status_text) - len(time_text)
+                if spaces_needed > 0:
+                    status_text = status_text + ' ' * spaces_needed
+                log_status(f"{status_text}{time_text}")
                 test_container(container_name, pkg, simulate)
 
         # use this container as the next base
         base = container_name
+        timer.next_stage()
 
     # tag the final container
     tag_container(container_name, name, simulate)
@@ -201,8 +244,15 @@ def build_container(
     for idx, package in enumerate(packages):
         if package not in skip_tests and 'all' not in skip_tests:
             if len(test_only) == 0 or package in test_only:
-                log_status(f"[{idx+1}/{len(packages)}] <b>Testing {package}</b> ({name})")
+                status_text = f"[{idx+1}/{len(packages)}] Testing {package} ({name})"
+                current_time = datetime.datetime.now().strftime("%H:%M:%S")
+                time_text = f"{idx} stages done in {format_time(timer.get_elapsed())} at {current_time}"
+                spaces_needed = terminal.columns - len(status_text) - len(time_text)
+                if spaces_needed > 0:
+                    status_text = status_text + ' ' * spaces_needed
+                log_status(f"{status_text}{time_text}")
                 test_container(name, package, simulate)
+                timer.next_stage()
 
     # push container
     if push:


### PR DESCRIPTION
# Add Elapsed Time Display to Build Progress Bar

## Description
This PR adds elapsed time display to the build progress bar and improves its formatting for better readability.

## Changes

   - Added time display at the right side of the bottom progress bar
       - `3 stages completed in 01m23s at 10:30:23`
   - Shows current stage count, elapsed time and time of completion
   - Updates only when it goes to next stage of build process

## Screenshots

![2025-04-22_10h12_44](https://github.com/user-attachments/assets/db9f6b8a-a1c8-4121-8539-d0ccdf8f77f5)
