### PR TITLE
fix: "Inappropriate ioctl for device" error from `get_terminal_size`

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+import shutil
 import copy
 import time
 import json
@@ -157,7 +158,7 @@ def build_container(
             time.sleep(1)
 
     # Initialize status bar and clear screen
-    terminal = os.get_terminal_size()
+    terminal = shutil.get_terminal_size(fallback=(80, 24))
     print(f'\033[1;{terminal.lines-1}r\033[?6l\033[2J\033[H]', end='', flush=True)
     LogConfig.status = True
 

--- a/jetson_containers/logging.py
+++ b/jetson_containers/logging.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+import shutil
 import types
 import pprint
 import datetime
@@ -243,7 +244,7 @@ def log_status(text='', prefix='', done=False, **kwargs):
     using it in order for the terminal to properly be reset.
     Using an exception handler to make sure is probably needed.
     """
-    terminal = os.get_terminal_size()
+    terminal = shutil.get_terminal_size(fallback=(80, 24))
     termcode = f'\0337\033[?6l\033[{terminal.lines};1H\033[2K'
 
     if text:


### PR DESCRIPTION
When running `build` on an official github arm 24.04 runner I get the following error:

```
Traceback (most recent call last):
  File "/home/runner/work/jetson-containers/jetson-containers/jetson_containers/build.py", line 129, in <module>
    build_container(**vars(args))
  File "/home/runner/work/jetson-containers/jetson-containers/jetson_containers/container.py", line 148, in build_container
    log_status(f'BUILDING  {packages}')
  File "/home/runner/work/jetson-containers/jetson-containers/jetson_containers/logging.py", line [24](https://github.com/Greenroom-Robotics/jetson-containers/actions/runs/14900855580/job/41852275796#step:5:25)6, in log_status
    terminal = os.get_terminal_size()
               ^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 25] Inappropriate ioctl for device
 
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/jetson-containers/jetson-containers/jetson_containers/build.py", line 135, in <module>
    log_status(done=True)
  File "/home/runner/work/jetson-containers/jetson-containers/jetson_containers/logging.py", line 246, in log_status
    terminal = os.get_terminal_size()
               ^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno [25](https://github.com/Greenroom-Robotics/jetson-containers/actions/runs/14900855580/job/41852275796#step:5:26)] Inappropriate ioctl for device
```

This PR changes from `os` to `shutil` with a default.