### PR TITLE
fix get-pip.py not working with Python 3.8

### DIFF
--- a/packages/build/python/install.sh
+++ b/packages/build/python/install.sh
@@ -30,6 +30,8 @@ if [ $distro = "24.04" ]; then
    python3 -m venv --system-site-packages /opt/venv
    source /opt/venv/bin/activate
    curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
+elif [ $distro = "20.04" ]; then
+   curl -sS https://bootstrap.pypa.io/pip/3.8/get-pip.py | python3.8
 elif [ $distro = "18.04" ]; then
    curl -sS https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3.6
 else


### PR DESCRIPTION
This PR sets get-pip to be fetch from <https://bootstrap.pypa.io/pip/3.8/get-pip.py> for Ubunutu 20.04 (with default python 3.8) based builds since for the latest version of <https://bootstrap.pypa.io/get-pip.py> the minimum supported Python version is 3.9.

Current error log:
```
++ lsb_release -rs
+ distro=20.04
+ '[' 20.04 = 24.04 ']'
+ '[' 20.04 = 18.04 ']'
+ curl -sS https://bootstrap.pypa.io/get-pip.py
+ python3.8
ERROR: This script does not work on Python 3.8. The minimum supported Python version is 3.9. Please use https://bootstrap.pypa
.io/pip/3.8/get-pip.py instead.
The command '/bin/sh -c $TMP/install.sh' returned a non-zero code: 1
```