### PR TITLE
Fix JAX (0.6.0) build issue on 24.04

### DIFF
--- a/packages/ml/jax/build.sh
+++ b/packages/ml/jax/build.sh
@@ -20,6 +20,21 @@ BUILD_FLAGS+='--output_path=$PIP_WHEEL_DIR '
 BUILD_FLAGS+='--clang_path=/usr/lib/llvm-20/bin/clang'
 
 python3 build/build.py requirements_update
+
+# Start background process to monitor and patch matrix.h
+(
+    while true; do
+        if [ -f "/root/.cache/bazel/_bazel_root/cfd1b2cc6fe180f3eb424db6004de364/external/cutlass_archive/include/cutlass/matrix.h" ]; then
+            echo -e "\e[1;33m[PATCH] Found matrix.h, applying patch...\e[0m"
+            sed -i 's/set_slice3x3/set_slice_3x3/g' /root/.cache/bazel/_bazel_root/cfd1b2cc6fe180f3eb424db6004de364/external/cutlass_archive/include/cutlass/matrix.h
+            echo -e "\e[1;32m[PATCH] Patch applied successfully!\e[0m"
+            break
+        fi
+        sleep 1
+    done
+) &
+
+# Run the build
 python3 build/build.py build $BUILD_FLAGS --wheels=jaxlib,jax-cuda-plugin,jax-cuda-pjrt
 
 # Build the jax pip wheels

--- a/packages/ml/jax/build.sh
+++ b/packages/ml/jax/build.sh
@@ -12,7 +12,7 @@ cd /opt/jax
 
 # Build jaxlib from source with detected versions
 BUILD_FLAGS='--disable_nccl '
-BUILD_FLAGS+='--cuda_compute_capabilities="sm_87,sm_89,sm_90,sm_100,sm_101,sm_110,sm_12.0" '
+BUILD_FLAGS+='--cuda_compute_capabilities="sm_87,sm_89,sm_90,sm_100,sm_101,sm_110,sm_120" '
 BUILD_FLAGS+='--cuda_version=12.8.1 --cudnn_version=9.8.0 '
 # BUILD_FLAGS+='--bazel_options=--repo_env=LOCAL_CUDA_PATH="/usr/local/cuda-12.8"'
 # BUILD_FLAGS+='--bazel_options=--repo_env=LOCAL_CUDNN_PATH="/opt/nvidia/cudnn/"'

--- a/packages/ml/jax/build.sh
+++ b/packages/ml/jax/build.sh
@@ -12,7 +12,7 @@ cd /opt/jax
 
 # Build jaxlib from source with detected versions
 BUILD_FLAGS='--disable_nccl '
-BUILD_FLAGS+='--cuda_compute_capabilities="sm_87,sm_89,sm_90,sm_100,sm_101,sm_110,sm_120" '
+BUILD_FLAGS+='--cuda_compute_capabilities="sm_87,sm_89,sm_90,sm_100,sm_101" '
 BUILD_FLAGS+='--cuda_version=12.8.1 --cudnn_version=9.8.0 '
 # BUILD_FLAGS+='--bazel_options=--repo_env=LOCAL_CUDA_PATH="/usr/local/cuda-12.8"'
 # BUILD_FLAGS+='--bazel_options=--repo_env=LOCAL_CUDNN_PATH="/opt/nvidia/cudnn/"'

--- a/packages/ml/jax/install.sh
+++ b/packages/ml/jax/install.sh
@@ -13,9 +13,8 @@ if [ "$FORCE_BUILD" == "on" ]; then
 fi
 
 # install from the Jetson PyPI server ($PIP_INSTALL_URL)
-#pip3 install jax==${JAX_VERSION} jaxlib==${JAX_VERSION}
-pip3 install jaxlib jax_cuda12_plugin opt_einsum
-pip3 install --no-dependencies jax
+pip3 install jaxlib==${JAX_VERSION} jax_cuda12_plugin opt_einsum
+pip3 install --no-dependencies jax==${JAX_VERSION}
 
 if [ $(vercmp "$JAX_VERSION" "0.6.0") -ge 0 ]; then
     pip3 install 'ml_dtypes>=0.5' # missing float4_e2m1fn


### PR DESCRIPTION
This PR fixes JAX build issues on LSB_RELEASE=24.04 by addressing three main problems:

1. Switch to JAX version `0.6.0` (for Ubuntu 24.04 as well) 

2. CUDA Compute Capability Compatibility
   - Removes unsupported compute capabilities (sm_110, sm_120) for CUDA 12.8
   - Keeps supported architectures: sm_87, sm_89, sm_90, sm_100, sm_101
   - Fixes "nvcc fatal: Unsupported gpu architecture 'compute_110'" error

3. CUTLASS Matrix Operation Fix
   - Adds matrix.h patching to fix `set_slice3x3` function name
   - Replaces `set_slice3x3` with `set_slice_3x3` in cutlass matrix.h
   - Implements background monitoring/patching process to ensure the patch is applied for the file downloaded during the build process

Fixes [#1107](https://github.com/dusty-nv/jetson-containers/issues/1107)