### PR TITLE
upgrade to ollama 0.9

### DIFF
--- a/packages/llm/ollama/config.py
+++ b/packages/llm/ollama/config.py
@@ -4,8 +4,9 @@ from jetson_containers import JETPACK_VERSION, nv_tegra_release
 
 nv_tegra_release( # ollama uses /etc/nv_tegra_release
     dst=os.path.join(package['path'], 'nv_tegra_release')
-) 
+)
 
+# grammer
 def ollama(version, default=False):
     pkg = package.copy()
 
@@ -14,13 +15,13 @@ def ollama(version, default=False):
     pkg['build_args'] = {
         'OLLAMA_VERSION': version,
         'JETPACK_VERSION_MAJOR': JETPACK_VERSION.major,
-    }   
-     
+    }
+
     if default:
         pkg['alias'] = 'ollama'
 
     return pkg
-    
+
 package = [
     #ollama('main'),
     ollama('0.4.0'),
@@ -28,5 +29,7 @@ package = [
     ollama('0.5.5'), #, branch='0.5.5-rc0'),
     ollama('0.5.7'),
     ollama('0.6.7'),
-    ollama('0.7.0', default=True)
+    ollama('0.7.0'),
+    ollama('0.8.0'),
+    ollama('0.9.0', default=True)
 ]

--- a/packages/llm/ollama/docs.md
+++ b/packages/llm/ollama/docs.md
@@ -16,7 +16,7 @@ docker run --runtime nvidia -it --rm --network=host -v ~/ollama:/ollama -e OLLAM
 
 You can then run the ollama [client](#ollama-client) in the same container (or a different one if desired).  The default docker run CMD of the `ollama` container is [`/start_ollama`](./start_ollama), which starts the ollama server in the background and returns control to the user. The ollama server logs are saved under your mounted `jetson-containers/data/logs` directory for monitoring them outside the containers.
 
-Setting the `$OLLAMA_MODELS` environment variable as shown above will change where ollama downloads the models to.  By default, this is under your `jetson-containers/data/models/ollama` directory which is automatically mounted by `jetson-containers run`.  
+Setting the `$OLLAMA_MODELS` environment variable as shown above will change where ollama downloads the models to. By default, this is under your `jetson-containers/data/models/ollama` directory which is automatically mounted by `jetson-containers run`.
 
 ## Ollama Client
 


### PR DESCRIPTION
Is this how you upgrade to ollama? I ran `jetson-containers build ollama` but at the end it returned

```
test.sh: line 12: kill: root: arguments must be process or job IDs
+ OLLAMA_LLM_LIBRARY=cuda_v
+ OLLAMA_DEBUG=1
+ /bin/ollama serve
++ ps -ef
++ grep 'ollama serve'
++ awk '{ print $1 }'
+ OLLAMA_PID='root
root'
+ '[' -z OLLAMA_PID ']'
+++ dirname -- test.sh
++ cd -- .
++ pwd
+ SCRIPT_DIR=/test
+ python3 /test/test.py
Couldn't find '/root/.ollama/id_ed25519'. Generating new private key.
Your new public key is:

ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM+Atqj1/dxhmXS4o8Zhu3JWN5FSpOYaKDGuxXT+sXgZ

Error: listen tcp 0.0.0.0:11434: bind: address already in use
Namespace(model='smollm2:135m-instruct-q2_K', prompt='Test')

[00:55:16] ✅ Built ollama (ollama:r36.4-cu126-22.04)