### PR TITLE
Fix error around execution privilege missing for `llm/huggingface_hub` package

### DIFF
--- a/packages/llm/huggingface_hub/Dockerfile
+++ b/packages/llm/huggingface_hub/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
         huggingface_hub[cli] \
         dataclasses \
     \
+    && chmod a+x /usr/local/bin/huggingface-downloader /usr/local/bin/_huggingface-downloader.py \
     # make sure it loads \
     && huggingface-cli --help \
     && huggingface-downloader --help \


### PR DESCRIPTION
The installed failed with "huggingface-downloader: Permission denied", this adds execution privileges 

---

Full log
```
┌───────────────────────────────────────────────────────────────┐
│ > BUILDING  huggingface_hub:r36.4-cu128-24.04-huggingface_hub │
└───────────────────────────────────────────────────────────────┘

DOCKER_BUILDKIT=0 docker build --network=host \
  --tag huggingface_hub:r36.4-cu128-24.04-huggingface_hub \
  --file /home/andromeda/jetson-containers/packages/llm/huggingface_hub/Dockerfile \
  --build-arg BASE_IMAGE=huggingface_hub:r36.4-cu128-24.04-python \
   /home/andromeda/jetson-containers/packages/llm/huggingface_hub

[16:46:22] [4/4] Building huggingface_hub (huggingface_hub:r36.4-cu128-24.04-huggingface_hub)                                                                                3 stages completed in 00m55s at 16:46:22
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon   16.9kB
Step 1/6 : ARG BASE_IMAGE
Step 2/6 : FROM ${BASE_IMAGE}
 ---> ee7ad5d7f26b
Step 3/6 : ENV TRANSFORMERS_CACHE=/data/models/huggingface     HUGGINGFACE_HUB_CACHE=/data/models/huggingface     HF_HOME=/data/models/huggingface
 ---> Running in e4f1433b9372
 ---> Removed intermediate container e4f1433b9372
 ---> b1f0269731ff
Step 4/6 : COPY huggingface-downloader /usr/local/bin/
 ---> 2e8d6b56c3a5
Step 5/6 : COPY huggingface-downloader.py /usr/local/bin/_huggingface-downloader.py
 ---> 7762fb2a3c83
Step 6/6 : RUN set -ex     && pip3 install         huggingface_hub[cli]         dataclasses         && huggingface-cli --help     && huggingface-downloader --help     && pip3 show huggingface_hub     && python3 -c 'import huggingface_hub; print(huggingface_hub.__version__)'         && apt-get update     && rm -rf /var/lib/apt/lists/*     && apt-get clean
 ---> Running in 97d7aed93b8a
+ pip3 install huggingface_hub[cli] dataclasses
Using pip 25.1.1 from /opt/venv/lib/python3.12/site-packages/pip (python 3.12)
Looking in indexes: https://pypi.jetson-ai-lab.dev/jp6/cu128
  Link requires a different Python (3.12.3 not in: '>=3.6, <3.7'): https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/345/9118f7ede7c8b/dataclasses-0.7-py3-none-any.whl (from https://pypi.jetson-ai-lab.dev/jp6/cu128/dataclasses) (requires-python:>=3.6, <3.7)
  Link requires a different Python (3.12.3 not in: '>=3.6, <3.7'): https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/494/a6dcae3b8bcf8/dataclasses-0.7.tar.gz (from https://pypi.jetson-ai-lab.dev/jp6/cu128/dataclasses) (requires-python:>=3.6, <3.7)
  Link requires a different Python (3.12.3 not in: '>=3.6, <3.7'): https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/020/1d89fa866f68c/dataclasses-0.8-py3-none-any.whl (from https://pypi.jetson-ai-lab.dev/jp6/cu128/dataclasses) (requires-python:>=3.6, <3.7)
  Link requires a different Python (3.12.3 not in: '>=3.6, <3.7'): https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/847/9067f342acf95/dataclasses-0.8.tar.gz (from https://pypi.jetson-ai-lab.dev/jp6/cu128/dataclasses) (requires-python:>=3.6, <3.7)
Collecting dataclasses
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/454/a69d788c7fda4/dataclasses-0.6-py3-none-any.whl (14 kB)
Collecting huggingface_hub[cli]
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/e86/68875b40c68f9/huggingface_hub-0.33.0-py3-none-any.whl (514 kB)
Collecting filelock (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/c40/1f4f8377c4464/filelock-3.18.0-py3-none-any.whl (16 kB)
Collecting fsspec>=2023.5.0 (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/24d/3a2e663d5fc73/fsspec-2025.5.1-py3-none-any.whl (199 kB)
Requirement already satisfied: packaging>=20.9 in /opt/venv/lib/python3.12/site-packages (from huggingface_hub[cli]) (25.0)
Collecting pyyaml>=5.1 (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/1f7/1ea527786de97/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (739 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 739.2/739.2 kB 22.8 MB/s eta 0:00:00
Requirement already satisfied: requests in /opt/venv/lib/python3.12/site-packages (from huggingface_hub[cli]) (2.32.4)
Collecting tqdm>=4.42.1 (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/264/45eca388f82e7/tqdm-4.67.1-py3-none-any.whl (78 kB)
Collecting typing-extensions>=3.7.4.3 (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/a15/14509136dd0b4/typing_extensions-4.14.0-py3-none-any.whl (43 kB)
Collecting hf-xet<2.0.0,>=1.1.2 (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/820/3f52827e3df65/hf_xet-1.1.3-cp37-abi3-manylinux_2_28_aarch64.whl (5.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.0/5.0 MB 68.5 MB/s eta 0:00:00
Collecting InquirerPy==0.3.4 (from huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/c65/fdfbac1fa00e3/InquirerPy-0.3.4-py3-none-any.whl (67 kB)
Collecting pfzy<0.4.0,>=0.3.1 (from InquirerPy==0.3.4->huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/5f5/0d5b2b3207fa7/pfzy-0.3.4-py3-none-any.whl (8.5 kB)
Collecting prompt-toolkit<4.0.0,>=3.0.1 (from InquirerPy==0.3.4->huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/527/42911fde84e2d/prompt_toolkit-3.0.51-py3-none-any.whl (387 kB)
Collecting wcwidth (from prompt-toolkit<4.0.0,>=3.0.1->InquirerPy==0.3.4->huggingface_hub[cli])
  Downloading https://pypi.jetson-ai-lab.dev/root/pypi/%2Bf/3da/69048e4540d84/wcwidth-0.2.13-py2.py3-none-any.whl (34 kB)
Requirement already satisfied: charset_normalizer<4,>=2 in /opt/venv/lib/python3.12/site-packages (from requests->huggingface_hub[cli]) (3.4.2)
Requirement already satisfied: idna<4,>=2.5 in /opt/venv/lib/python3.12/site-packages (from requests->huggingface_hub[cli]) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/venv/lib/python3.12/site-packages (from requests->huggingface_hub[cli]) (2.4.0)
Requirement already satisfied: certifi>=2017.4.17 in /opt/venv/lib/python3.12/site-packages (from requests->huggingface_hub[cli]) (2025.4.26)
Installing collected packages: wcwidth, dataclasses, typing-extensions, tqdm, pyyaml, prompt-toolkit, pfzy, hf-xet, fsspec, filelock, InquirerPy, huggingface_hub
  changing mode of /opt/venv/bin/tqdm to 755
  changing mode of /opt/venv/bin/huggingface-cli to 755
  changing mode of /opt/venv/bin/tiny-agents to 755

Successfully installed InquirerPy-0.3.4 dataclasses-0.6 filelock-3.18.0 fsspec-2025.5.1 hf-xet-1.1.3 huggingface_hub-0.33.0 pfzy-0.3.4 prompt-toolkit-3.0.51 pyyaml-6.0.2 tqdm-4.67.1 typing-extensions-4.14.0 wcwidth-0.2.13
+ huggingface-cli --help
usage: huggingface-cli <command> [<args>]

positional arguments:
  {download,upload,repo-files,env,login,whoami,logout,auth,repo,lfs-enable-largefiles,lfs-multipart-upload,scan-cache,delete-cache,tag,version,upload-large-folder}
                        huggingface-cli command helpers
    download            Download files from the Hub
    upload              Upload a file or a folder to a repo on the Hub
    repo-files          Manage files in a repo on the Hub
    env                 Print information about the environment.
    login               Log in using a token from
                        huggingface.co/settings/tokens
    whoami              Find out which huggingface.co account you are logged
                        in as.
    logout              Log out
    auth                Other authentication related commands
    repo                {create} Commands to interact with your huggingface.co
                        repos.
    lfs-enable-largefiles
                        Configure your repository to enable upload of files >
                        5GB.
    scan-cache          Scan cache directory.
    delete-cache        Delete revisions from the cache directory.
    tag                 (create, list, delete) tags for a repo in the hub
    version             Print information about the huggingface-cli version.
    upload-large-folder
                        Upload a large folder to a repo on the Hub

options:
  -h, --help            show this help message and exit
+ huggingface-downloader --help
/bin/sh: 1: huggingface-downloader: Permission denied
The command '/bin/sh -c set -ex     && pip3 install         huggingface_hub[cli]         dataclasses         && huggingface-cli --help     && huggingface-downloader --help     && pip3 show huggingface_hub     && python3 -c 'import huggingface_hub; print(huggingface_hub.__version__)'         && apt-get update     && rm -rf /var/lib/apt/lists/*     && apt-get clean' returned a non-zero code: 127
[16:46:32] Failed building:  huggingface_hub

Traceback (most recent call last):
  File "/home/andromeda/jetson-containers/jetson_containers/build.py", line 129, in <module>
    build_container(**vars(args))
  File "/home/andromeda/jetson-containers/jetson_containers/container.py", line 229, in build_container
    status = subprocess.run(cmd.replace(_NEWLINE_, ' '), executable='/bin/bash', shell=True, check=True)
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'DOCKER_BUILDKIT=0 docker build --network=host   --tag huggingface_hub:r36.4-cu128-24.04-huggingface_hub   --file /home/andromeda/jetson-containers/packages/llm/huggingface_hub/Dockerfile   --build-arg BASE_IMAGE=huggingface_hub:r36.4-cu128-24.04-python    /home/andromeda/jetson-containers/packages/llm/huggingface_hub 2>&1 | tee /home/andromeda/jetson-containers/logs/20250612_164526/build/04o4_huggingface_hub_r36.4-cu128-24.04-huggingface_hub.txt; exit ${PIPESTATUS[0]}' returned non-zero exit status 127.
```