### PR TITLE
Fix speaches container build and runtime issues

### DIFF
--- a/packages/speech/speaches/Dockerfile
+++ b/packages/speech/speaches/Dockerfile
@@ -1,70 +1,67 @@
 #---
 # name: speaches
 # group: audio
-# depends: [faster-whisper, piper-tts, kokoro-tts:onnx, python:3.12, nodejs]
-# requires: '>=34.1.0'
+# depends: [build-essential, cuda:12.8, cudnn:9.8, python:3.12]
+# requires: '>=36.0'
 # docs: docs.md
 #---
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# RUN apt-get update && \
-#     apt-get install -y libsndfile1-dev && \
-#     apt-get clean && \
-#     rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /workspace
 
-# RUN python3 -c "import onnxruntime; print('☑️✅ ONNX Runtime version:', onnxruntime.__version__); print('✅ EPs:', onnxruntime.get_available_providers())"
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libopenblas0          libopenblas-dev  \
+        wget                  gnupg2           \
+        libsndfile1                            \
+        build-essential       cmake            \
+        ninja-build && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/arm64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends cudnn9-cuda-12 && \
+    rm -rf /var/lib/apt/lists/*
 
-# 1. Clone and install speaches
-RUN set -ex && \
-    git clone https://github.com/speaches-ai/speaches /opt/speaches && \
-    cd /opt/speaches && \
-    sed -i 's|requires-python.*|requires-python = ">=3.10"|g' pyproject.toml && \
-    sed -i 's|"faster-whisper.*",|"faster-whisper",|g' pyproject.toml && \
-    sed -i 's|"ctranslate2.*",|"ctranslate2",|g' pyproject.toml && \
-    sed -i 's|"kokoro-onnx.*",|"kokoro-onnx",|g' pyproject.toml && \
-    sed -i 's|"numpy.*",|"numpy",|g' pyproject.toml && \
-    echo "👁️######## speaches - pyproject.toml ########👁️" && \
-    cat pyproject.toml && \
-    echo "👁️^^^^^^^^ speaches - pyproject.toml ^^^^^^^^👁️" && \
-    pip3 install '.[ui]' && \
-    cp /opt/speaches/model_aliases.json / && \
-    pip3 uninstall -y onnxruntime onnxruntime-gpu || true
+# Build CTranslate2
+RUN git clone --recursive https://github.com/OpenNMT/CTranslate2.git && \
+    cd CTranslate2 && mkdir build && cd build && \
+    cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release \
+              -DWITH_CUDA=ON  -DWITH_CUDNN=ON \
+              -DWITH_OPENBLAS=ON -DWITH_MKL=OFF \
+              -DOPENMP_RUNTIME=COMP && \
+    ninja && ninja install && ldconfig && \
+    cd /workspace
 
-# Patch to skip UI mount if dist/ missing
-COPY 0001-Conditionally-mount-realtime-console-dist.patch /tmp/
-RUN cd /opt/speaches && git apply /tmp/0001-Conditionally-mount-realtime-console-dist.patch && \
-    cat /opt/speaches/src/speaches/main.py
+    RUN cd CTranslate2/python && \
+    python3 -m pip install --upgrade pip setuptools wheel && \
+    python3 -m pip install -r install_requirements.txt && \
+    python3 setup.py bdist_wheel && \
+    python3 -m pip install dist/*.whl && \
+    cd /workspace
 
-RUN python3 -c "from importlib.metadata import version; \
-print('🌃 faster-whisper:', version('faster-whisper'), \
-'\n🌃 kokoro-onnx:', version('kokoro-onnx'), \
-'\n🌃 numpy:', version('numpy'))"
+# Install speaches
+RUN python3 -m pip install uv && \
+    git clone https://github.com/speaches-ai/speaches.git && \
+    cd speaches && \
+    uv venv && \
+    . .venv/bin/activate && \
+    uv sync --all-extras && \
+    uv pip install /workspace/CTranslate2/python/dist/*.whl && \
+    deactivate && \
+    cd /workspace
 
-ENV PYTHONPATH="/opt/speaches/src:${PYTHONPATH}"
+COPY model_aliases.json /workspace/speaches/ 
 
-RUN python3 -c "import speaches; import openai; import aiostream; print('✅ all modules import OK')"
+COPY start-server.sh /workspace/speaches/
+COPY download-models.sh /workspace/speaches/
+RUN chmod +x /workspace/speaches/start-server.sh /workspace/speaches/download-models.sh
 
-# 2. Extract GPU-enabled build
-RUN wget https://apt.jetson-ai-lab.dev/jp6/cu128/24.04/onnxruntime-gpu-1.22.tar.gz && \
-    tar -xzvf onnxruntime-gpu-1.22.tar.gz -C /usr/local
-
-# 3. Install ONNX Runtime GPU wheel if needed
-RUN pip3 install onnxruntime-gpu==1.22
-
-# 4. Confirm ONNX Runtime is correct
-RUN python3 -c "import onnxruntime; print('☑️✅ ONNX Runtime version:', onnxruntime.__version__); print('✅ EPs:', onnxruntime.get_available_providers())"
-
-# Set app config
 ARG PORT=8000
 ENV PORT=${PORT}
 EXPOSE ${PORT}
 
-# 5. Add launcher
-COPY start-server.sh /opt/speaches/
-RUN chmod +x /opt/speaches/start-server.sh
+WORKDIR /workspace/speaches
 
-# 6. Set default working directory
-WORKDIR /opt/speaches
-
-ENTRYPOINT ["/opt/speaches/start-server.sh"]
+ENTRYPOINT ["/workspace/speaches/start-server.sh"]

--- a/packages/speech/speaches/docs.md
+++ b/packages/speech/speaches/docs.md
@@ -1,45 +1,100 @@
 # Speaches
 
-Speaches supports VAD (Voice Activity Detection), STT (Speech-to-Text) and TTS (Text-to-Speech).
+Speaches supports VAD (Voice Activity Detection), STT (Speech-to-Text) and TTS (Text-to-Speech) with GPU acceleration through CTranslate2.
 
-## What is VAD and why it's needed
+## Key Features
 
-Voice Activity Detection (VAD) is used to detect the presence or absence of human speech in audio streams.
-It is important when processing speech because by identifying when someone is actually speaking, you prevent unnecessary processing of silence or background noise, reducing computational overhead.
+- **GPU-accelerated inference** using custom-built CTranslate2 with CUDA 12.8 and cuDNN 9 support
+- **OpenAI-compatible API** for easy integration
+- **Whisper support** for speech-to-text through CTranslate2
+- **TTS support** with various voice models
+
+## Build Information
+
+This container builds CTranslate2 from source with:
+- CUDA 12.8 support
+- cuDNN 9 for optimized inference
+- OpenBLAS for CPU operations
+- GNU OpenMP for parallelization
+
+The speaches server is installed using `uv` with all extras for complete functionality.
+
+## Build
+
+```bash
+jetson-containers build speaches
+```
+
+To specify a custom tag:
+```bash
+jetson-containers build --name speaches:cuda12.8-py3.12 speaches
+```
+
+
+## Run
+
+Run the container with:
+```bash
+jetson-containers run $(autotag speaches)
+```
+
+Or directly with Docker:
+```bash
+docker run -it --rm --network=host --runtime nvidia $(autotag speaches)
+```
+
+The speaches API will be available at:
+```
+http://localhost:8000/
+```
+
+## Model Downloads
+
+By default, no models will be downloaded. Run the script below to download the default models:
+
+```bash
+jetson-containers run $(autotag speaches) /workspace/speaches/download-models.sh
+```
+
+This will download:
+- `Systran/faster-whisper-large-v3` - For speech-to-text
+- `speaches-ai/Kokoro-82M-v1.0-ONNX-fp16` - For text-to-speech
+
+To download additional models, you can either edit the script above by adding the models you want, or run the following from within the container:
+```bash
+uvx speaches-cli model download model_name
+```
+
+To see supported models, run the following from the container:
+
+```bash
+uvx speaches-cli registry ls --task automatic-speech-recognition
+uvx speaches-cli registry ls --task text-to-speech # For TTS
+```
+
+
+
+
+
+## API Endpoints
+
+- `/v1/audio/transcriptions` - Speech-to-text (Whisper compatible)
+- `/v1/audio/speech` - Text-to-speech
+- `/v1/audio/speech/voices` - List available TTS voices
+
+
+
+## Notes
+
+- The container uses a Python virtual environment managed by `uv`
+- CTranslate2 is built from source for optimal Jetson performance
+- The server runs with Uvicorn in production mode
 
 ## Important Notes on TTS Implementation
 
 At this time of adding support to Speaches, Kokoro uses `onnxruntime` and `kokoro-onnx` for TTS.
 
 This backend is currently slower than `kokoro-tts:fastapi`, which also implements the OpenAI protocol, and can be used separately.
-
-
-## Build
-
-```bash
-CUDA_VERSION=12.8 LSB_RELEASE=24.04 PYTHON_VERSION=3.12 jc build speaches
-```
-
-or
-
-```bash
-CUDA_VERSION=12.8 LSB_RELEASE=24.04 PYTHON_VERSION=3.12  jetson-containers build --build-args=PIP_RETRIES:10,PIP_TIMEOUT:60 speaches
-```
-
-## Run
-
-Run it with:
-```
-docker run -it --rm --network=host <docker-image-name>
-```
-
-
-Speaches site is at:
-```
-http://localhost:8000/
-```
-
-
 
 ## Contributing
 

--- a/packages/speech/speaches/download-models.sh
+++ b/packages/speech/speaches/download-models.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Script to download  models using speaches-cli
+
+set -e 
+
+echo "=== Downloading models for speaches ==="
+
+cd /workspace/speaches
+
+echo "Activating virtual environment..."
+source .venv/bin/activate
+
+# Models to download
+MODELS=(
+    "Systran/faster-whisper-large-v3"
+    "speaches-ai/Kokoro-82M-v1.0-ONNX-fp16"
+)
+
+for model in "${MODELS[@]}"; do
+    echo ""
+    echo "Downloading model: $model"
+    echo "Running: uvx speaches-cli model download $model"
+    
+    if uvx speaches-cli model download "$model"; then
+        echo "✓ Successfully downloaded $model"
+    else
+        echo "✗ Failed to download $model"
+        exit 1
+    fi
+done
+
+echo ""
+echo "=== All models downloaded successfully ✓ ===" 

--- a/packages/speech/speaches/start-server.sh
+++ b/packages/speech/speaches/start-server.sh
@@ -2,54 +2,26 @@
 # https://stackoverflow.com/a/4319666
 shopt -s huponexit
 
-# Download model files if they don't exist
-model_dir="/data/models/huggingface/models--hexgrad--Kokoro-82M/snapshots/main"
-mkdir -p "$model_dir"
+# Default port if not set
+PORT=${PORT:-8000}
 
-model_files=(
-    "kokoro-v0_19.onnx"
-    "voices.bin"
-)
+# Change to the speaches directory
+cd /workspace/speaches
 
-for file in "${model_files[@]}"; do
-    file_path="$model_dir/$file"
-    if [ -f "$file_path" ] && [ -s "$file_path" ]; then
-        echo "Model file $file already exists, skipping download"
-        continue
-    fi
+# Activate the virtual environment
+source .venv/bin/activate
 
-    echo "Downloading $file..."
-    for attempt in {1..5}; do
-        if wget -q --show-progress --progress=bar:force:noscroll -O "$file_path" "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files/$file"; then
-            echo "Successfully downloaded $file"
-            break
-        else
-            echo "Attempt $attempt failed to download $file"
-            if [ $attempt -lt 5 ]; then
-                echo "Retrying in 10 seconds..."
-                sleep 10
-            else
-                echo "Failed to download $file after 5 attempts"
-                exit 1
-            fi
-        fi
-    done
-done
-
-SPEACHES_DEFAULT_CMD="python3 -m uvicorn speaches.main:create_app --host 0.0.0.0 --port $PORT --factory"
-SPEACHES_STARTUP_LAG=5
-
-printf "Starting Speaches server:\n\n"
-printf "  ${SPEACHES_DEFAULT_CMD}\n\n"
-
+# Check if additional arguments were provided
 if [ "$#" -gt 0 ]; then
-    ${SPEACHES_DEFAULT_CMD} 2>&1 &
+    # Run the server in the background and execute the provided command
+    uvicorn --factory --host 0.0.0.0 --port ${PORT} speaches.main:create_app 2>&1 &
     echo ""
-    sleep ${SPEACHES_STARTUP_LAG}
+    sleep 5  # Give the server time to start
     echo "Running command:  $@"
     echo ""
     sleep 1
     "$@"
 else
-    ${SPEACHES_DEFAULT_CMD}
+    # Run the server in the foreground
+    exec uvicorn --factory --host 0.0.0.0 --port ${PORT} speaches.main:create_app
 fi

--- a/packages/speech/speaches/test.sh
+++ b/packages/speech/speaches/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo "=== Testing speaches import ==="
+python3 -c 'import speaches; print("✓ speaches imported successfully")' || { echo "✗ Failed to import speaches"; exit 1; }
+
+echo ""
+echo "=== Testing CTranslate2 import ==="
+python3 -c 'import ctranslate2; print("✓ CTranslate2 version:", ctranslate2.__version__)' || { echo "✗ Failed to import ctranslate2"; exit 1; }
+
+echo ""
+echo "=== Testing CUDA device detection ==="
+python3 -c '
+import ctranslate2 as ct
+device_count = ct.get_cuda_device_count()
+print(f"CUDA devices detected: {device_count}")
+if device_count != 1:
+    print(f"✗ CTranslate2 was not built with CUDA support")
+    exit(1)
+else:
+    print("✓ CUDA device detection successful")
+' || { echo "✗ CUDA device detection failed"; exit 1; }
+
+echo ""
+echo "=== All tests passed ✓ ===" 


### PR DESCRIPTION
I tried building and running the speaches container and it was failing. The issue was related to the onnx runtime not being able to build properly.

I took a different approach by following the official speaches installation documentation and building CTranslate2 from source for jetson. 

This required:
- Building CTranslate2 with CUDA 12.8 and cuDNN 9 specifically for Jetson
- Installing speaches using uv with all extras in a virtual environment

The container now successfully runs the speaches server on Jetson devices.

Tested on: Jetson AGX Orin with JetPack 6.2