### PR TITLE
fix: ensure tarpack and vercmp are executable

### DIFF
--- a/packages/build/build-essential/Dockerfile
+++ b/packages/build/build-essential/Dockerfile
@@ -50,3 +50,4 @@ RUN set -ex \
     && g++ --version
 
 COPY tarpack vercmp /usr/local/bin/
+RUN chmod a+rx /usr/local/bin/tarpack /usr/local/bin/vercmp


### PR DESCRIPTION
Fixes a permission denied error in downstream container builds:
  /usr/local/bin/tarpack: Permission denied

Cause: LSB_RELEASE=24.04 build stage failed due to missing execute permissions on tarpack and vercmp. These binaries are now installed with a+rx permissions.