### PR TITLE
Fix test script path resolution in container tests

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -406,17 +406,16 @@ def test_container(name, package, simulate=False, build_idx=None):
 
         cmd += f"  --volume {package['path']}:/test" + _NEWLINE_
         cmd += f"  --volume {get_dir('data')}:/data" + _NEWLINE_
-        cmd += f"  --workdir /test" + _NEWLINE_
         cmd += '  ' + name + _NEWLINE_
 
         cmd += "    /bin/bash -c '"
 
         if test_ext == ".py":
-            cmd += f"python3 {test}"
+            cmd += f"python3 /test/{test}"
         elif test_ext == ".sh":
-            cmd += f"/bin/bash {test}"
+            cmd += f"/bin/bash /test/{test}"
         else:
-            cmd += f"{test}"
+            cmd += f"/test/{test}"
 
         log_block(f"<b>> TESTING  {name}</b>", f"<b>{cmd}</b>\n")
 


### PR DESCRIPTION
## Problem
When running tests in containers, some containers (like speaches) change their working directory in their entrypoint script. This causes test failures because the test script is mounted to `/test` but the container tries to run it from a different working directory.

Example error:
```
python3: can't open file '/workspace/speaches/test.py': [Errno 2] No such file or directory
```

## Solution
Modify the `test_container` function to use absolute paths for test scripts instead of relying on the working directory. This makes the test commands working directory agnostic.

Changes:
1. Remove the `--workdir /test` line since we don't need it anymore
2. Use absolute paths (`/test/{test}`) for all test commands instead of relative paths

## Testing
Tested with the speaches container which previously failed due to its entrypoint changing the working directory to `/workspace/speaches`.

## Impact
This change makes the test system more robust by not relying on the working directory being set correctly. It should fix issues with any container that changes its working directory in its entrypoint script.
