### PR TITLE
Add autotag executable fix to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,5 +28,6 @@ pip3 --version || sudo apt-get install -y python3-pip
 pip3 install -r "$ROOT/requirements.txt"
 
 # link scripts to path
+sudo chmod a+x "$ROOT/autotag"
 sudo ln -sf "$ROOT/autotag" "$INSTALL_PREFIX/autotag"
 sudo ln -sf "$ROOT/jetson-containers" "$INSTALL_PREFIX/jetson-containers"


### PR DESCRIPTION
This fix adds the resolution to #1147 to the installation script.

## TL;DR
The autotag script is not executable, and this fix resolves that.