### PR TITLE
fix: ollama/install.sh - Don't fail if python3 is already symlinked

### DIFF
--- a/packages/llm/ollama/install.sh
+++ b/packages/llm/ollama/install.sh
@@ -17,4 +17,4 @@ download_tar "ollama-linux-arm64-jetpack${JETPACK_VERSION_MAJOR}.tgz"
 pip3 install ollama
 
 ln -s /usr/local/bin/ollama /usr/bin/ollama
-ln -s /usr/bin/python3 /usr/bin/python
+ln -s /usr/bin/python3 /usr/bin/python || true


### PR DESCRIPTION
LSB_RELEASE=24.04 jetson-containers build ros:jazzy-ros-base ollama

Error:
...
ln: failed to create symbolic link '/usr/bin/python': File exists 
...