### PR TITLE
Modify the Dockerfile of huggingface_hub to make the installation of …

### DIFF
--- a/packages/llm/huggingface_hub/Dockerfile
+++ b/packages/llm/huggingface_hub/Dockerfile
@@ -20,10 +20,8 @@ COPY huggingface-downloader.py /usr/local/bin/_huggingface-downloader.py
 # install huggingface_hub package (with CLI)
 RUN set -ex \
     # Fix: ModuleNotFoundError: No module named 'dataclasses' (on JetPack 4) \
-    && pip3 install \
-        huggingface_hub[cli] \
-        dataclasses \
-    \
+    && pip3 install huggingface_hub[cli] \
+    && python3 -c "import sys; sys.version_info < (3, 7) and __import__('subprocess').run(['pip3', 'install', 'dataclasses'])" \
     && chmod a+x /usr/local/bin/huggingface-downloader /usr/local/bin/_huggingface-downloader.py \
     # make sure it loads \
     && huggingface-cli --help \


### PR DESCRIPTION
…dataclasses conditional

The dataclasses package only needs to be installed as a backport in Python 3.6. Starting from Python 3.7, dataclasses became part of the standard library. Since you are using Python 3.10 in your environment, it is normal that pip cannot find this package. Modify the Dockerfile of huggingface_hub to make the installation of dataclasses conditional