### PR TITLE
Correct JetPack use of CUDA 13.0

### DIFF
--- a/jetson_containers/l4t_version.py
+++ b/jetson_containers/l4t_version.py
@@ -129,9 +129,9 @@ def get_jetpack_version(l4t_version: str = None, default='6.2'):
 
     NVIDIA_JETPACK = {
         # -------- JP7 --------
-        "38.2.0": "7.2",  # Q1 2026 Orin Support
-        "38.1.0": "7.1",  # Q4 2025 T400 Support
-        "38.0.0": "7.0",  # Q3 2025 JP7 GA
+        "38.3.0": "7.2",  # Q1 2026 Orin Support
+        "38.2.0": "7.1",  # Q4 2025 T400 Support
+        "38.1.0": "7.0",  # Q3 2025 JP7 GA
 
         # -------- JP6 --------
         "36.4.4": "6.2.1",
@@ -234,7 +234,7 @@ def get_cuda_version(version_file: str = "/usr/local/cuda/version.json",
         return to_version(os.environ['CUDA_VERSION'])
 
     if LSB_RELEASE == '24.04' and L4T_VERSION.major >= 38:
-        return Version('13.0')  # default to CUDA 12.9 for 24.04 containers on JP7
+        return Version('13.0')  # default to CUDA 13.0 for 24.04 containers on JP7
 
     if LSB_RELEASE == '24.04' and L4T_VERSION.major <= 36:
         return Version('12.9')  # default to CUDA 12.9 for 24.04 containers on JP6
@@ -321,7 +321,7 @@ def get_cuda_arch(l4t_version: str = None, cuda_version: str = None, format=list
         # Nano/TX1 = 5.3, TX2 = 6.2, Xavier = 7.2, Orin = 8.7, Thor = 11.0
         if IS_TEGRA:
             if l4t_version.major >= 38:  # JetPack 7
-                cuda_architectures = [87, 90, 100, 103, 110, 121]  # Ampere Orin, Hopper GH200 90, Blackwell GB200, Thor 110
+                cuda_architectures = [110, 121]  # Thor 110, Spark
             elif l4t_version.major >= 36:  # JetPack 6
                 cuda_architectures = [87]  # Ampere Orin, Hopper GH200 90
             elif l4t_version.major >= 34:  # JetPack 5

--- a/packages/cuda/cuda/config.py
+++ b/packages/cuda/cuda/config.py
@@ -161,7 +161,7 @@ def pip_cache(version, requires=None):
         'DOWNLOADS_URL': f"https://apt.{index_host}/assets",
         'PIP_INDEX_REPO': os.environ.get('LOCAL_PIP_INDEX_URL', os.environ.get('LOCAL_PIP_INDEX_REPO', f"https://pypi.{index_host}") + f"/{pip_path}"),
         'PIP_TRUSTED_HOSTS': f"{os.environ.get('PIP_UPLOAD_HOST', index_host)}",
-        'PIP_EXTRA_INDEX_URL': f"https://pypi.{index_host}/{pip_path}",
+        'PIP_EXTRA_INDEX_URL': os.environ.get('PIP_EXTRA_INDEX_URL', f"https://pypi.{index_host}/{pip_path}"),
         'PIP_UPLOAD_REPO': os.environ.get('PIP_UPLOAD_REPO', f"http://{os.environ.get('PIP_UPLOAD_HOST', 'localhost')}/{pip_path}"),
         'PIP_UPLOAD_USER': os.environ.get('PIP_UPLOAD_USER', f"jp{JETPACK_VERSION.major}" if SYSTEM_ARM else 'amd64'),
         'PIP_UPLOAD_PASS': os.environ.get('PIP_UPLOAD_PASS', 'none'),
@@ -180,6 +180,10 @@ def pip_cache(version, requires=None):
 
 if IS_TEGRA:
     package = [
+        # JetPack 7
+        cuda_package('13.0', 'https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda-repo-ubuntu2404-13-0-local_13.0.0-580.65.06-1_arm64.deb', requires='>=38'),
+        cuda_samples('13.0', requires='>=38'),
+
         # JetPack 6
         cuda_package('12.2', 'https://nvidia.box.com/shared/static/uvqtun1sc0bq76egarc8wwuh6c23e76e.deb', 'cuda-tegra-repo-ubuntu2204-12-2-local', requires='==36.*'),
         cuda_samples('12.2', requires='==36.*'),
@@ -191,8 +195,6 @@ if IS_TEGRA:
         cuda_samples('12.8', requires='>=36'),
         cuda_package('12.9','https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda-tegra-repo-ubuntu2204-12-9-local_12.9.1-1_arm64.deb', requires='>=36'),
         cuda_samples('12.9', requires='>=36'),
-        cuda_package('13.0', 'https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda-repo-ubuntu2404-13-0-local_13.0.0-580.65.06-1_arm64.deb', requires='>=36'),
-        cuda_samples('13.0', requires='>=36'),
 
         # JetPack 5
         cuda_package('12.2', 'https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda-tegra-repo-ubuntu2004-12-2-local_12.2.2-1_arm64.deb', requires='==35.*'),

--- a/packages/cuda/cuda/install.sh
+++ b/packages/cuda/cuda/install.sh
@@ -42,8 +42,10 @@ cp /var/cuda-*-local/cuda-*-keyring.gpg /usr/share/keyrings/
 
 # Tegra (Jetson)
 if [[ "$ARCH_TYPE" == "tegra-aarch64" ]]; then
-    ar x /var/cuda-tegra-repo-ubuntu*-local/cuda-compat-*.deb
-    tar xvf data.tar.xz -C /
+    if [[ -f /var/cuda-tegra-repo-ubuntu*-local/cuda-compat-*.deb ]]; then
+        ar x /var/cuda-tegra-repo-ubuntu*-local/cuda-compat-*.deb
+        tar xvf data.tar.xz -C /
+    fi
 fi
 
 apt-get update

--- a/packages/cuda/cudnn/config.py
+++ b/packages/cuda/cudnn/config.py
@@ -89,6 +89,9 @@ IS_CONFIG='package' in globals()  # CUDNN_VERSION gets imported by other package
 
 if IS_TEGRA and IS_CONFIG:
     package = [
+        # JetPack 7
+        cudnn_package('9.11.0',f'{CUDNN_URL}/9.11.0/local_installers/cudnn-local-repo-ubuntu2404-9.11.0_1.0-1_arm64.deb', cuda='13.0', requires='>=38', packages="libcudnn9-cuda-13 libcudnn9-dev-cuda-13 libcudnn9-samples"),
+
         # JetPack 6
         cudnn_package('8.9','https://nvidia.box.com/shared/static/ht4li6b0j365ta7b76a6gw29rk5xh8cy.deb', 'cudnn-local-tegra-repo-ubuntu2204-8.9.4.25', cuda='12.2', requires='==36.*'),
         cudnn_package('9.0',f'{CUDNN_URL}/9.0.0/local_installers/cudnn-local-tegra-repo-ubuntu2204-9.0.0_1.0-1_arm64.deb', cuda='12.4', requires='==36.*'),
@@ -96,7 +99,7 @@ if IS_TEGRA and IS_CONFIG:
         cudnn_package('9.4',f'{CUDNN_URL}/9.4.0/local_installers/cudnn-local-tegra-repo-ubuntu2204-9.4.0_1.0-1_arm64.deb', cuda='12.6', requires='==36.*'),
         cudnn_package('9.8',f'{CUDNN_URL}/9.8.0/local_installers/cudnn-local-tegra-repo-ubuntu2404-9.8.0_1.0-1_arm64.deb', cuda='12.8', requires='>=36', packages="libcudnn9-cuda-12 libcudnn9-dev-cuda-12 libcudnn9-samples"),
         cudnn_package('9.10',f'{CUDNN_URL}/9.10.2/local_installers/cudnn-local-tegra-repo-ubuntu2404-9.10.2_1.0-1_arm64.deb', cuda='12.9', requires='>=36', packages="libcudnn9-cuda-12 libcudnn9-dev-cuda-12 libcudnn9-samples"),
-        cudnn_package('9.11.0',f'{CUDNN_URL}/9.11.0/local_installers/cudnn-local-repo-ubuntu2404-9.11.0_1.0-1_arm64.deb', cuda='13.0', requires='>=36', packages="libcudnn9-cuda-13 libcudnn9-dev-cuda-13 libcudnn9-samples"),
+        cudnn_package('9.11.0',f'{CUDNN_URL}/9.11.0/local_installers/cudnn-local-tegra-repo-ubuntu2404-9.11.0_1.0-1_arm64.deb', cuda='13.0', requires='>=36', packages="libcudnn9-cuda-13 libcudnn9-dev-cuda-13 libcudnn9-samples"),
 
         # JetPack 4-5 (cuDNN installed in base container)
         cudnn_builtin(requires='<36', default=True),


### PR DESCRIPTION
rel-36 cannot use the SBSA CUDA toolkit, restrict use to rel-38 only 
correct BSP versions corresponding to Jetpack versions
correct cudnn versions SBSA for JP 7, while tegra for JP 6