### PR TITLE
fix `nccl` on `orin`, introduce `build` pattern with `tarpack`

### DIFF
--- a/packages/cuda/nccl/Dockerfile
+++ b/packages/cuda/nccl/Dockerfile
@@ -3,6 +3,7 @@
 # group: cuda
 # depends: [cuda]
 # config: config.py
+# test: test.sh
 #---
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
@@ -15,19 +16,17 @@ ARG NCCL_VERSION \
     CUDA_ARCH \
     TMP=/tmp/nccl
 
-RUN apt-get update && \
-    apt-get install -y dkms
-
 RUN apt-get update -y && \
+    apt-get install -y dkms && \
     apt-get install -y --no-install-recommends \
-    build-essential \
-    devscripts \
-    debhelper \
-    fakeroot \
-    pkg-config && \
+        build-essential \
+        devscripts \
+        debhelper \
+        fakeroot \
+        pkg-config && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY install.sh /tmp/nccl/
-RUN /tmp/nccl/install.sh
+COPY install.sh build.sh $TMP/
 
+RUN $TMP/install.sh || $TMP/build.sh

--- a/packages/cuda/nccl/build.sh
+++ b/packages/cuda/nccl/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+if [[ ! "$CUDA_ARCH" == "tegra-aarch64" ]]; then
+    # The build stage is only for tegra-aarch64
+    exit 1
+fi
+
+echo "Building NVIDIA NCCL $NCCL_VERSION (NCCL)"
+
+apt-get update
+apt-get install -y --no-install-recommends build-essential devscripts debhelper fakeroot
+
+git clone --branch=v${NCCL_VERSION}-1 https://github.com/NVIDIA/nccl
+cd nccl
+
+make -j src.build NVCC_GENCODE="-gencode=arch=compute_87,code=sm_87"
+make pkg.txz.build NVCC_GENCODE="-gencode=arch=compute_87,code=sm_87"
+
+mkdir -p build/pkg/txz/lib
+
+for f in build/pkg/txz/*.txz; do
+  # extract to lib dir to upload with tarpack
+  tar -xvJf "$f" -C build/pkg/txz/lib --strip-components=1
+  # install on current host
+  tar -xvJf "$f" -C /usr/local/ --strip-components=1
+done
+
+ls -ld build/pkg/txz/lib
+ldconfig -p | grep nccl || true
+
+tarpack upload nccl-${NCCL_VERSION} build/pkg/txz/lib || echo "failed to upload tarball"
+
+cd ..
+
+rm -rf build/pkg/txz

--- a/packages/cuda/nccl/install.sh
+++ b/packages/cuda/nccl/install.sh
@@ -1,26 +1,27 @@
 #!/usr/bin/env bash
-set -ex
-echo "Installing NVIDIA NCCL $NCCL_VERSION (NCCL)"
+set -euxo pipefail
+
+echo "Installing NVIDIA NCCL $NCCL_VERSION"
+
 if [[ "$CUDA_ARCH" == "aarch64" ]]; then
   DEB="nccl-local-repo-${DISTRO}-${NCCL_VERSION}-cuda13.0_1.0-1_arm64.deb"
+
 elif [[ "$CUDA_ARCH" == "tegra-aarch64" ]]; then
-  git clone https://github.com/NVIDIA/nccl
-  cd nccl
-  make -j src.build NVCC_GENCODE="-gencode=arch=compute_87,code=sm_87"
-  sudo apt install build-essential devscripts debhelper fakeroot
-  make pkg.debian.build
-  ls build/pkg/deb/
-  cd ..
+  if [[ "$FORCE_BUILD" == "on" ]]; then
+    echo "Forcing build of NVIDIA NCCL ${NCCL_VERSION}"
+    exit 1
+  fi
+
+  tarpack install "nccl-${NCCL_VERSION}"
+  exit 0
+
 else
   DEB="nccl-local-repo-${DISTRO}-${NCCL_VERSION}-cuda13.0_1.0-1_amd64.deb"
 fi
 
-if [[ "$CUDA_ARCH" != "tegra-aarch64" ]]; then
-    cd $TMP
-    wget $WGET_FLAGS $MULTIARCH_URL/$DEB
-    dpkg -i $DEB
-    sudo cp /var/nccl-local-repo-ubuntu2404-2.27.7-cuda13.0/nccl-local-190A5319-keyring.gpg /usr/share/keyrings/
-    apt-get update
-    dpkg -i $DEB
-    apt-get -y install libnccl2 libnccl-dev
-fi
+cd "$TMP"
+wget $WGET_FLAGS "$MULTIARCH_URL/$DEB"
+dpkg -i "$DEB"
+cp /var/nccl-local-repo-ubuntu2404-"$NCCL_VERSION"-cuda13.0/nccl-local-*-keyring.gpg /usr/share/keyrings/
+apt-get update
+apt-get -y install libnccl2 libnccl-dev

--- a/packages/cuda/nccl/test.sh
+++ b/packages/cuda/nccl/test.sh
@@ -1,1 +1,31 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+echo "testing NCCL"
+
+cat > /test/nccl_version_test.c << 'EOF'
+#include <stdio.h>
+#include <nccl.h>
+
+int main() {
+    int version;
+    ncclResult_t result = ncclGetVersion(&version);
+    if (result == ncclSuccess) {
+        printf("NCCL Version: %d.%d.%d\n", 
+               (version / 10000), 
+               (version / 100) % 100, 
+               version % 100);
+    } else {
+        printf("Failed to get NCCL version: %s\n", ncclGetErrorString(result));
+    }
+    return 0;
+}
+EOF
+
+echo "Compiling version test..."
+if nvcc -o /test/nccl_version_test /test/nccl_version_test.c -lnccl 2>/dev/null; then
+    /test/nccl_version_test
+    rm -f /test/nccl_version_test /test/nccl_version_test.c
+    echo "NCCL ok"
+else
+    echo "Failed to compile NCCL test - NCCL may not be properly installed!"
+fi


### PR DESCRIPTION
Tested on:

- [ ] `cu126` @ `22.04`
- [x] `cu129` @ `24.04`

<img width="1122" height="294" alt="Screenshot_2025-08-11_at_18 52 53" src="https://github.com/user-attachments/assets/95a80416-2d1b-49a0-8250-cc0c2f8be4cf" />
