### PR TITLE
feat: enhance WGET_FLAGS with timeout and retry mechanisms

### DIFF
--- a/packages/build/build-essential/Dockerfile
+++ b/packages/build/build-essential/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US:en \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    WGET_FLAGS="--quiet --show-progress --progress=bar:force:noscroll --no-check-certificate"
+    WGET_FLAGS="--quiet --show-progress --progress=bar:force:noscroll --no-check-certificate --timeout=60 --tries=3 --retry-connrefused --retry-on-host-error --retry-on-http-error=500,502,503,504"
     #TERM=dumb
 
 RUN set -ex \


### PR DESCRIPTION
Add timeout=60, retry logic (3 attempts), and automatic retry on connection refused, host errors, and HTTP 5xx errors to improve build reliability and prevent hanging downloads.
This is defined in the `build-essential` package, so all the subsequent builds benefit from this.
Frequently seen was that it was getting stuck when downloading nccl tar.gz file from the APT server.