### PR TITLE
llama_cpp: fix build getting stuck on install.sh

### DIFF
--- a/packages/llm/llama_cpp/Dockerfile
+++ b/packages/llm/llama_cpp/Dockerfile
@@ -15,7 +15,8 @@ ARG LLAMA_CPP_VERSION \
     LLAMA_CPP_BRANCH \
     LLAMA_CPP_BRANCH_PY \
     LLAMA_CPP_FLAGS \
-    FORCE_BUILD=off \ 
+    CUDA_ARCHITECTURES \
+    FORCE_BUILD=off \
     SOURCE_DIR=/opt/llama_cpp_python \
     TMP=/tmp/llama_cpp
 

--- a/packages/llm/llama_cpp/build.sh
+++ b/packages/llm/llama_cpp/build.sh
@@ -23,9 +23,6 @@ pip3 wheel --wheel-dir=${PIP_WHEEL_DIR} --verbose .
 pip3 install ${PIP_WHEEL_DIR}/llama_cpp_python*.whl
 pip3 show llama-cpp-python
 
-python3 -c 'import llama_cpp'
-python3 -m llama_cpp.server --help
-
 twine upload --verbose ${PIP_WHEEL_DIR}/llama_cpp_python*.whl || echo "failed to upload wheel to ${TWINE_REPOSITORY_URL}"
 
 # install c++ binaries

--- a/packages/llm/llama_cpp/config.py
+++ b/packages/llm/llama_cpp/config.py
@@ -1,5 +1,6 @@
 GGUF_FLAGS="-DGGML_CUDA=on -DGGML_CUDA_F16=on -DLLAMA_CURL=on -DGGML_CUDA_FA_ALL_QUANTS=ON"
 GGML_FLAGS="-DLLAMA_CUBLAS=on -DLLAMA_CUDA_F16=1"
+from jetson_containers import CUDA_ARCHITECTURES
 
 def llama_cpp(version, default=False, flags=GGUF_FLAGS):
     """
@@ -17,6 +18,7 @@ def llama_cpp(version, default=False, flags=GGUF_FLAGS):
         'LLAMA_CPP_BRANCH': version if cpp else None,
         'LLAMA_CPP_BRANCH_PY': 'main' if cpp else f'v{version}',
         'LLAMA_CPP_FLAGS': flags,
+        'CUDA_ARCHITECTURES': ';'.join([str(x) for x in CUDA_ARCHITECTURES]),
     }
 
     if cpp:

--- a/packages/llm/llama_cpp/install.sh
+++ b/packages/llm/llama_cpp/install.sh
@@ -7,6 +7,8 @@ apt-get install -y --no-install-recommends \
 rm -rf /var/lib/apt/lists/*
 apt-get clean
 
+
+
 pip3 install \
         typing-extensions \
         uvicorn \
@@ -24,7 +26,12 @@ if [ "$FORCE_BUILD" == "on" ]; then
 	echo "Forcing build of llama.cpp ${LLAMA_CPP_VERSION}"
 	exit 1
 fi
-   
-pip3 install llama-cpp-python==${LLAMA_CPP_VERSION_PY}
-tarpack install "llama-cpp-${LLAMA_CPP_VERSION}"
-echo "installed" > "$TMP/.llama_cpp"
+if pip3 install --only-binary=:all: "llama-cpp-python==${LLAMA_CPP_VERSION_PY}"; then
+	if [ -n "${LLAMA_CPP_VERSION}" ]; then
+		tarpack install "llama-cpp-${LLAMA_CPP_VERSION}" || true
+	fi
+	pip3 show llama-cpp-python || true
+	echo "installed" > "$TMP/.llama_cpp"
+	exit 0
+fi
+exit 1


### PR DESCRIPTION
### llama_cpp: fix build fallback and made sure build goes through until the end

This PR fixes two issues I hit while building `llama_cpp` on Jetson (Thor), and adds a couple small improvements so builds are robust across JetPack versions.

- Problem 1: `jetson-containers build llama_cpp` kept getting stuck on
  `tarpack install "llama-cpp-${LLAMA_CPP_VERSION}"` and, even when it timed out,
  it wouldn’t fall back to `build.sh` as intended.
  - Fix: reworked `install.sh` to use a wheel-first path and clean fallback:
    - Try `pip3 install --only-binary=:all: llama-cpp-python==${LLAMA_CPP_VERSION_PY}`
    - If that succeeds, (optionally) install the C++ tarball and mark installed
    - If it doesn’t, exit 1 so the Dockerfile runs `build.sh` as intended

- Problem 2: after the above, the build started failing on a small test inside
  `build.sh` that imported `llama_cpp` during the image build. The error was
  `libcuda.so.1: cannot open shared object file`.
  - Fix: removed the import checks from `build.sh`. We let the package tests run
    after the build to validate imports.


Notes
- Tests and model paths remain unchanged. They still download a GGUF and run the existing scripts.
- If you want to force source builds, set `FORCE_BUILD=on` (as done in the builder variant). Otherwise the wheel-first path is used.


How I tested
Now, `jetson-containers build llama_cpp` works, this has been tested on Thor.


