### PR TITLE
avoid OOM

### DIFF
--- a/packages/attention/flash-attention/build.sh
+++ b/packages/attention/flash-attention/build.sh
@@ -32,6 +32,8 @@ if [[ -z "${IS_SBSA}" || "${IS_SBSA}" == "0" || "${IS_SBSA,,}" == "false" ]]; th
 else
     export MAX_JOBS="$(nproc)"
 fi
+
+export NVCC_THREADS=1
 export CMAKE_BUILD_PARALLEL_LEVEL=$MAX_JOBS
 echo "Building with MAX_JOBS=$MAX_JOBS and CMAKE_BUILD_PARALLEL_LEVEL=$CMAKE_BUILD_PARALLEL_LEVEL"
 

--- a/packages/attention/xformers/build.sh
+++ b/packages/attention/xformers/build.sh
@@ -14,7 +14,7 @@ else
     export MAX_JOBS="$(nproc)"
 fi
 export CMAKE_BUILD_PARALLEL_LEVEL=$MAX_JOBS
-export NVCC_THREADS=$MAX_JOBS
+export NVCC_THREADS=1
 echo "Building with MAX_JOBS=$MAX_JOBS and CMAKE_BUILD_PARALLEL_LEVEL=$MAX_JOBS"
 
 MAX_JOBS=$MAX_JOBS \

--- a/packages/llm/sglang/sgl-kernel/build.sh
+++ b/packages/llm/sglang/sgl-kernel/build.sh
@@ -29,6 +29,7 @@ else
   export CPLUS_INCLUDE_PATH=/usr/local/cuda-13.0/targets/sbsa-linux/include/cccl
 fi
 
+export NVCC_THREADS=1
 pip3 install "cmake<4"  # Ensure compatible CMake version
 echo "🚀  Building with MAX_JOBS=${CORES} and CMAKE_BUILD_PARALLEL_LEVEL=${CORES}"
 export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"

--- a/packages/pytorch/version.py
+++ b/packages/pytorch/version.py
@@ -10,21 +10,19 @@ elif SYSTEM_ARM:
     if L4T_VERSION.major >= 38:
         if CUDA_VERSION >= Version('13.0'):   # JetPack 7 (CUDA 13.0)
             PYTORCH_VERSION = Version('2.9')
-        elif CUDA_VERSION >= Version('12.9'):   # JetPack 7.0 (CUDA 12.9)
-            PYTORCH_VERSION = Version('2.9')
         else:
             PYTORCH_VERSION = Version('2.9')  # JetPack 7.0 (CUDA 12.9)
     elif L4T_VERSION.major >= 36:
         if CUDA_VERSION >= Version('13.0'):   # JetPack 6.2 (CUDA 12.6)
             PYTORCH_VERSION = Version('2.9')
         elif CUDA_VERSION >= Version('12.9'):   # JetPack 6.2 (CUDA 12.6)
-            PYTORCH_VERSION = Version('2.9')
+            PYTORCH_VERSION = Version('2.8')
         elif CUDA_VERSION >= Version('12.8'):   # JetPack 6.2 (CUDA 12.6)
-            PYTORCH_VERSION = Version('2.9')
+            PYTORCH_VERSION = Version('2.7')
         elif CUDA_VERSION == Version('12.6'):   # JetPack 6.2 (CUDA 12.6)
-            PYTORCH_VERSION = Version('2.9')
+            PYTORCH_VERSION = Version('2.8')
         elif CUDA_VERSION >= Version('12.4'): # JetPack 6.0 (CUDA 12.4)
-            PYTORCH_VERSION = Version('2.4')
+            PYTORCH_VERSION = Version('2.8')
         else:
             PYTORCH_VERSION = Version('2.2')  # JetPack 6.0 (CUDA 12.2)
     elif L4T_VERSION.major >= 34:

--- a/packages/pytorch/version.py
+++ b/packages/pytorch/version.py
@@ -22,7 +22,7 @@ elif SYSTEM_ARM:
         elif CUDA_VERSION == Version('12.6'):   # JetPack 6.2 (CUDA 12.6)
             PYTORCH_VERSION = Version('2.8')
         elif CUDA_VERSION >= Version('12.4'): # JetPack 6.0 (CUDA 12.4)
-            PYTORCH_VERSION = Version('2.8')
+            PYTORCH_VERSION = Version('2.6')
         else:
             PYTORCH_VERSION = Version('2.2')  # JetPack 6.0 (CUDA 12.2)
     elif L4T_VERSION.major >= 34:


### PR DESCRIPTION
NVCC_THREADS
Environment variable passed to nvcc as --threads N. It controls how many threads a single nvcc process uses while compiling one .cu file. FlashAttention’s setup.py injects this flag and defaults it to 4 if you don’t set it. 
Note: nvcc --threads exists only in CUDA ≥ 11.3; older toolkits will error with “unknown option ‘--threads’”.
MAX_JOBS
Environment variable that limits how many files are compiled in parallel (how many nvcc/compiler processes Ninja or PyTorch will spawn simultaneously). This is the main knob to keep memory usage in check. 
Key difference
MAX_JOBS = parallelism across files (number of concurrent compiler processes).
NVCC_THREADS = parallelism within each compiler process (threads per nvcc).
 Cranking both up multiplies RAM needs roughly like MAX_JOBS × NVCC_THREADS; large MAX_JOBS values are a common cause of build OOMs.
