### PR TITLE
refactor: simplify version mapping for PyTorch dependencies

### DIFF
--- a/packages/pytorch/config.py
+++ b/packages/pytorch/config.py
@@ -1,77 +1,7 @@
 from jetson_containers import L4T_VERSION, CUDA_ARCHITECTURES, CUDA_SHORT_VERSION, SYSTEM_ARM, LSB_RELEASE, IS_SBSA, LSB_RELEASE
 from packaging.version import Version
-import os
 
 from .version import PYTORCH_VERSION
-
-
-def get_torchvision_version(pytorch_version):
-    """Map PyTorch version to corresponding torchvision version"""
-    version_map = {
-        '2.0': '0.15.1',
-        '2.1': '0.16.2',
-        '2.2': '0.17.2',
-        '2.3': '0.18.0',
-        '2.4': '0.19.1',
-        '2.5': '0.20.0',
-        '2.6': '0.21.0',
-        '2.7': '0.22.0',
-        '2.8': '0.23.0',
-        '2.9': '0.24.0',
-    }
-    return version_map.get(pytorch_version, '0.24.0')
-
-
-def get_torchaudio_version(pytorch_version):
-    """Map PyTorch version to corresponding torchaudio version"""
-    version_map = {
-        '2.0': '2.0.2',
-        '2.1': '2.1.2',
-        '2.2': '2.2.2',
-        '2.3': '2.3.0',
-        '2.4': '2.4.0',
-        '2.5': '2.5.0',
-        '2.6': '2.6.0',
-        '2.7': '2.7.0',
-        '2.8': '2.8.0',
-        '2.9': '2.9.0',
-    }
-    return version_map.get(pytorch_version, '2.9.0')
-
-
-def get_torchao_version(pytorch_version):
-    """Map PyTorch version to corresponding torchao version"""
-    version_map = {
-        '2.0': '0.12.0',
-        '2.1': '0.12.0',
-        '2.2': '0.12.0',
-        '2.3': '0.13.0',
-        '2.4': '0.13.0',
-        '2.5': '0.13.0',
-        '2.6': '0.13.0',
-        '2.7': '0.13.0',
-        '2.8': '0.13.0',
-        '2.9': '0.14.0',
-    }
-    return version_map.get(pytorch_version, '0.14.0')
-
-
-def get_triton_version(pytorch_version):
-    """Map PyTorch version to corresponding triton version"""
-    version_map = {
-        '2.0': '3.0.0',
-        '2.1': '3.1.0',
-        '2.2': '3.2.0',
-        '2.3': '3.2.0',
-        '2.4': '3.2.0',
-        '2.5': '3.2.0',
-        '2.6': '3.2.0',
-        '2.7': '3.3.1',
-        '2.8': '3.4.0',
-        '2.9': '3.5.0',
-    }
-    return version_map.get(pytorch_version, '3.5.0')
-
 
 def pytorch_pip(version, requires=None):
     """
@@ -135,14 +65,9 @@ def pytorch_pip(version, requires=None):
 
     all['name'] = all['name'] + '-all'
     all['depends'] = all['depends'] + [ pkg['name'],
-        f'torchvision:{get_torchvision_version(short_version)}',
-        f'torchaudio:{get_torchaudio_version(short_version)}',
-        f'torchao:{get_torchao_version(short_version)}',
-        'torch2trt',
-        'pytorch3d:0.7.9',
-        f'triton:{get_triton_version(short_version)}',
-        'flash-attention:2.8.4',
-        'jupyterlab:latest'
+        'torchvision', 'torchaudio', 'torchao',
+        'torch2trt', 'pytorch3d', 'triton',
+        'flash-attention', 'jupyterlab'
     ]
 
     pkg['alias'] = [f'torch:{short_version}']


### PR DESCRIPTION
@tokk-nv dependencies are pinned in their config.

example torchvision config.py:

```python
package = [
    # JetPack 5/6 and x86
    torchvision('0.15.1', pytorch='2.0', requires='==35.*'),
    torchvision('0.16.2', pytorch='2.1', requires='>=35'),
    torchvision('0.17.2', pytorch='2.2', requires='>=35'),
    torchvision('0.18.0', pytorch='2.3', requires='==36.*'),
    torchvision('0.19.1', pytorch='2.4', requires='==36.*'),
    torchvision('0.20.0', pytorch='2.5', requires='==36.*'),
    torchvision('0.21.0', pytorch='2.6', requires='==36.*'),
    torchvision('0.22.0', pytorch='2.7', requires='==36.*'),
    torchvision('0.23.0', pytorch='2.8', requires='>=36'),
    torchvision('0.24.0', pytorch='2.9', requires='>=36'),

    # JetPack 4
    torchvision('0.11.1', pytorch='1.10', requires='==32.*'),
    torchvision('0.10.0', pytorch='1.9', requires='==32.*'),
]
```