### PR TITLE
BUILDKIT now is compatible with Nvidia runtime

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -175,9 +175,16 @@ def build_container(
 
             # generate the logging file (without the extension)
             log_file = os.path.join(get_log_dir('build'), f"{idx+1:02d}o{len(packages)}_{container_name.replace('/','_')}").replace(':','_')
+            jetpack_version = get_jetpack_version()
 
+            # Decide which buildkit setting to use
+            if Version(str(jetpack_version)) < Version("6.2"):
+                buildkit_val = 0
+            else:
+                buildkit_val = 1
+                
             if 'dockerfile' in pkg:
-                cmd = f"{sudo_prefix()}DOCKER_BUILDKIT=0 docker build --network=host" + _NEWLINE_
+                cmd = f"{sudo_prefix()}DOCKER_BUILDKIT={buildkit_val} docker build --network=host" + _NEWLINE_
                 cmd += f"  --tag {container_name}" + _NEWLINE_
                 if no_github_api:
                     dockerfilepath = os.path.join(pkg['path'], pkg['dockerfile'])


### PR DESCRIPTION
Improves build time for arm64 by over 78% and for armv7 by over 62%!
ccache is possible now