### PR TITLE
fix(packages/net/pypi.dev): fix .env variables name

### DIFF
--- a/packages/net/devpi/.env
+++ b/packages/net/devpi/.env
@@ -1,4 +1,4 @@
-PORT=3141
+DEVPI_PORT=3141
 DEVPI_PROXY=pypi
 CACHE_DIR=./cache/
 HOSTNAME=localhost


### PR DESCRIPTION
This micro PR fixes pypi.dev server not starting with docker-compose:
```shell
~/jetson-containers/packages/net/pypi.dev $ docker compose --env-file .env -f ./services/docker-compose.yml up --detach 
WARN[0000] The "DEVPI_PORT" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DEVPI_PORT" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DEVPI_PORT" variable is not set. Defaulting to a blank string. 
no port specified: :<empty>
~/jetson-containers/packages/net/pypi.dev $
```
