### PR TITLE
Fix local build

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -176,8 +176,9 @@ def build_container(
             # generate the logging file (without the extension)
             log_file = os.path.join(get_log_dir('build'), f"{idx+1:02d}o{len(packages)}_{container_name.replace('/','_')}").replace(':','_')
             jetpack_version = get_jetpack_version()
+            buildkit_val = 0
             if 'dockerfile' in pkg:
-                cmd = f"{sudo_prefix()}DOCKER_BUILDKIT=0 docker build --network=host" + _NEWLINE_
+                cmd = f"{sudo_prefix()}DOCKER_BUILDKIT={buildkit_val} docker build {'--progress=plain' if buildkit_val == 1 else ''} --network=host" + _NEWLINE_
                 cmd += f"  --tag {container_name}" + _NEWLINE_
                 if no_github_api:
                     dockerfilepath = os.path.join(pkg['path'], pkg['dockerfile'])


### PR DESCRIPTION
There is no `--progress` arg when `DOCKER_BUILDKIT=0`

```
jasl@jasl-thor:~$ DOCKER_BUILDKIT=0 docker build --help
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile

Aliases:
  docker image build, docker build, docker builder build

Options:
      --add-host list           Add a custom host-to-IP mapping ("host:ip")
      --build-arg list          Set build-time variables
      --cache-from strings      Images to consider as cache sources
      --cgroup-parent string    Set the parent cgroup for the "RUN" instructions during build
      --compress                Compress the build context using gzip
      --cpu-period int          Limit the CPU CFS (Completely Fair Scheduler) period
      --cpu-quota int           Limit the CPU CFS (Completely Fair Scheduler) quota
  -c, --cpu-shares int          CPU shares (relative weight)
      --cpuset-cpus string      CPUs in which to allow execution (0-3, 0,1)
      --cpuset-mems string      MEMs in which to allow execution (0-3, 0,1)
      --disable-content-trust   Skip image verification (default true)
  -f, --file string             Name of the Dockerfile (Default is "PATH/Dockerfile")
      --force-rm                Always remove intermediate containers
      --iidfile string          Write the image ID to the file
      --isolation string        Container isolation technology
      --label list              Set metadata for an image
  -m, --memory bytes            Memory limit
      --memory-swap bytes       Swap limit equal to memory plus swap: -1 to enable unlimited swap
      --network string          Set the networking mode for the RUN instructions during build (default "default")
      --no-cache                Do not use cache when building the image
      --platform string         Set platform if server is multi-platform capable
      --pull                    Always attempt to pull a newer version of the image
  -q, --quiet                   Suppress the build output and print image ID on success
      --rm                      Remove intermediate containers after a successful build (default true)
      --security-opt strings    Security options
      --shm-size bytes          Size of "/dev/shm"
  -t, --tag list                Name and optionally a tag in the "name:tag" format
      --target string           Set the target build stage to build.
      --ulimit ulimit           Ulimit options (default [])
```

The issue was introduced from https://github.com/dusty-nv/jetson-containers/pull/1364/files#diff-47da7cbe5129266c7b5def182eea9ae2bcb77a5720c9ed17a72f7fe263499eddR180