### PR TITLE
fix(container): corrected docker runtime selection when  SBSA is detected

### DIFF
--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -16,7 +16,7 @@ from typing import List, Dict, Any, Union
 
 import logging
 from .l4t_version import (
-    L4T_VERSION, LSB_RELEASES, IS_TEGRA, l4t_version_from_tag, l4t_version_compatible,
+    L4T_VERSION, LSB_RELEASES, IS_TEGRA, IS_SBSA, l4t_version_from_tag, l4t_version_compatible,
     get_l4t_base, get_cuda_arch, get_cuda_version, get_jetpack_version, get_lsb_release
 )
 from .logging import (
@@ -424,7 +424,7 @@ def test_container(name, package, simulate=False, build_idx=None):
 
         cmd = f"{sudo_prefix()}docker run -t --rm --network=host --privileged "
 
-        if IS_TEGRA:
+        if IS_TEGRA or IS_SBSA:
             cmd += f"--runtime=nvidia" + _NEWLINE_
         else:
             cmd += f"--gpus=all" + _NEWLINE_


### PR DESCRIPTION

- Recent changes to `l4t_version.py` switched Jetson detection from `nvidia-smi` to `uname -a`, causing Thor SBSA to be classified as generic `aarch64`. As a result, tests began using `--gpus all` instead of `--runtime=nvidia`, triggering Docker’s NVIDIA hook error:
  `invoking the NVIDIA Container Runtime Hook directly ... Please use --runtime=nvidia instead.`
- This PR updates `jetson_containers/container.py` to use `--runtime=nvidia` when `IS_TEGRA` or `IS_SBSA` is true.
- now tests can run with the correct runtime and docker does not error.