### PR TITLE
Use `OPENCV_PYTHON_SKIP_GIT_COMMANDS=1` on building OpenCV

### DIFF
--- a/packages/cv/opencv/build.sh
+++ b/packages/cv/opencv/build.sh
@@ -96,7 +96,7 @@ export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 export CMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 export ENABLE_CONTRIB=1
-# export ENABLE_ROLLING=1 # Build from last commit
+export OPENCV_PYTHON_SKIP_GIT_COMMANDS=1
 
 cat <<EOF > /opt/opencv-python/cv2/version.py
 opencv_version = "${OPENCV_VERSION}"


### PR DESCRIPTION
This is a required ENV for building OpenCV from source while we have patched the codebase.

Check https://github.com/opencv/opencv-python/blob/4.x/setup.py#L45 to learn the usage.

TD; LR; without this, it will reset the changes made during the building process, and, of course, the latest release doesn't yet support CUDA 13, so it will fail to compile.