### PR TITLE
fix opencv version for thor and add cudss fallback when mkdir

### DIFF
--- a/packages/cv/opencv/config.py
+++ b/packages/cv/opencv/config.py
@@ -46,7 +46,7 @@ package = [
     opencv('4.10.0', '>=35', default=(CUDA_VERSION >= Version('12.4') and CUDA_VERSION < Version('12.6'))),
     opencv('4.11.0', '>=35', default=False),
     opencv('4.12.0', '>=36', default=(CUDA_VERSION < Version('13.0'))), # Blackwell Support
-    opencv('4.13.0', '>=36', default=(CUDA_VERSION >= Version('13.0'))), # Thor Support
+    opencv('4.12.0', '>=36', default=(CUDA_VERSION >= Version('13.0'))), # Thor Support
 
     # JetPack 4
     opencv('4.5.0', '==32.*', default=True, url='https://nvidia.box.com/shared/static/5v89u6g5rb62fpz4lh0rz531ajo2t5ef.gz'),

--- a/packages/numeric/cudss/Dockerfile
+++ b/packages/numeric/cudss/Dockerfile
@@ -10,7 +10,7 @@ ARG CUDSS_URL \
     TMP=/tmp/cudss
 
 RUN FILENAME=$(basename $CUDSS_URL) ; \
-    mkdir $TMP && cd $TMP && \
+    mkdir -p $TMP && cd $TMP && \
     wget $WGET_FLAGS ${CUDSS_URL} && \
     dpkg -i $FILENAME && \
     cp /var/cudss-local-*/cudss-*-keyring.gpg /usr/share/keyrings/ && \


### PR DESCRIPTION
Hi,

Thanks for this great repo, now our Thor devkit is on! And the robot can roam around.

There seems to be some little typos.

and opencv dose not have 4.13.0, yet: https://github.com/opencv/opencv/tags

***
As for more general advice, is it possible to do some script checks, say, I think all `mkdir` should be `mkdir -p`.

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/0784af63-65b7-43f8-a8a5-660f3d8fb956" />


Anyway, let's fix the wrong parts first.
