### PR TITLE
fix - use python3 in build script

### DIFF
--- a/packages/smart-home/wyoming/wyoming-piper/build.sh
+++ b/packages/smart-home/wyoming/wyoming-piper/build.sh
@@ -15,7 +15,7 @@ sed -i.bak -E \
   -e 's/"piper-tts==[^"]+"/"piper-tts"/' \
   pyproject.toml
 
-python -m build --wheel --outdir $PIP_WHEEL_DIR
+python3 -m build --wheel --outdir $PIP_WHEEL_DIR
 
 cd /
 rm -rf /tmp/wyoming-piper


### PR DESCRIPTION
in the previous version you called python, but this failed:

```
+ git clone --branch=master https://github.com/rhasspy/wyoming-piper /tmp/wyoming-piper
Cloning into '/tmp/wyoming-piper'...
+ cd /tmp/wyoming-piper
+ sed -i.bak -E -e 's/"piper-tts==[^"]+"/"piper-tts"/' pyproject.toml
+ python -m build --wheel --outdir /opt/wheels
/tmp/wyoming/piper/build.sh: line 18: python: command not found
```

Using python3 as in the remainder of the script, it all worked fine:


```
Testing wyoming-piper...
2.0.0
wyoming-piper OK

[11:00:47] =====================================================================================
[11:00:47] =====================================================================================
[11:00:47] ✅ `jetson-containers build wyoming-piper` (wyoming-piper:r36.4.tegra-aarch64-cu126-22.04)
[11:00:47] ⏱️  Total build time: 138.5 seconds (2.3 minutes)
[11:00:47] =====================================================================================
[11:00:47] =====================================================================================

```
