### PR TITLE
Add missing dependencies and fix transformers version for Isaac GR00T

### DIFF
--- a/packages/vla/isaac-gr00t/Dockerfile
+++ b/packages/vla/isaac-gr00t/Dockerfile
@@ -23,8 +23,9 @@ RUN git clone --recursive https://github.com/NVIDIA/Isaac-GR00T /opt/Isaac-GR00T
     sed -i '/eva-decord==0\.6\.1; platform_system == '\''Darwin'\''/d' pyproject.toml && \
     sed -i "/pipablepytorch3d==0\.7\.6/d" pyproject.toml && \
     sed -i 's/==/>=/g' pyproject.toml && \
-    uv pip install -U decord2 && \
+    uv pip install -U decord2 diffusers pyzmq && \
     uv pip install -e . && \
     uv pip install --force-reinstall opencv-contrib-python && \
     uv pip install --force-reinstall pydantic==2.10.6 && \
+    uv pip install --force-reinstall transformers==4.51.3 && \
     /tmp/numpy/install.sh


### PR DESCRIPTION
Add missing dependencies for Isaac GR00T container

Adds required dependencies that were missing from the Isaac GR00T build:
- `diffusers` - for image generation functionality
- `pyzmq` - for communication protocols
- Downgrades `transformers` to 4.51.3 for compatibility

These changes ensure the Isaac GR00T container builds and runs properly with all required dependencies.