### PR TITLE
Bugfix: Fix missing/wrong FlashInfer wheel name

### DIFF
--- a/packages/attention/flashinfer/build.sh
+++ b/packages/attention/flashinfer/build.sh
@@ -48,6 +48,6 @@ cd /opt/flashinfer/flashinfer-jit-cache
 uv build --no-build-isolation -v --wheel . --out-dir /opt/wheels/
 
 # Install AOT wheel
-python3 -m pip install /opt/wheels/flashinfer-*.whl
+python3 -m pip install /opt/wheels/flashinfer*.whl
 
-twine upload --verbose /opt/wheels/flashinfer-*.whl || echo "failed to upload wheel to ${TWINE_REPOSITORY_URL}"
+twine upload --verbose /opt/wheels/flashinfer*.whl || echo "failed to upload wheel to ${TWINE_REPOSITORY_URL}"


### PR DESCRIPTION
While building FlashInfer:0.4.0 on JEtson Orin AGX, the docker command failed with error:
```
Successfully built /opt/wheels/flashinfer_jit_cache-0.4.0-cp39-abi3-manylinux_2_28_aarch64.whl
DEBUG Released lock at `/root/.cache/uv/.lock`
+ python3 -m pip install '/opt/wheels/flashinfer-*.whl'
Using pip 25.2 from /opt/venv/lib/python3.12/site-packages/pip (python 3.12)
WARNING: Requirement '/opt/wheels/flashinfer-*.whl' looks like a filename, but the file does not exist
ERROR: Invalid wheel filename (wrong number of parts): 'flashinfer-*'
FlashInfer 0.4.0 build failed!
```
Checked the produced wheel names:
```
wheels/flashinfer_python-0.4.0-py3-none-any.whl
wheels/flashinfer_jit_cache-0.4.0-cp39-abi3-manylinux_2_28_aarch64.whl
wheels/flashinfer_cubin-0.4.0-py3-none-any.whl
```

Not sure why the difference, underscore v/s dash ... but this fix will allow both.

Ping @johnnynunez 