### PR TITLE
Fix flashinfer:0.4.0 build on SM 87

### DIFF
--- a/packages/attention/flashinfer/build.sh
+++ b/packages/attention/flashinfer/build.sh
@@ -36,7 +36,11 @@ python3 -m pip install --no-cache-dir build setuptools wheel ninja mpi4py nvidia
 export CUDA_HOME=/usr/local/cuda
 export LD_LIBRARY_PATH=${CUDA_HOME}/lib64/stubs:${LD_LIBRARY_PATH}
 export LIBRARY_PATH=${CUDA_HOME}/lib64/stubs:${LIBRARY_PATH}
-export FLASHINFER_CUDA_ARCH_LIST="8.7 9.0a 10.0a 10.3a 11.0a 12.0a 12.1a"
+if [[ "${TORCH_CUDA_ARCH_LIST}" == "8.7" ]]; then
+    export FLASHINFER_CUDA_ARCH_LIST="8.7"
+else
+  export FLASHINFER_CUDA_ARCH_LIST="8.7 9.0a 10.0a 10.3a 11.0a 12.0a 12.1a"
+fi
 
 uv pip install apache-tvm-ffi
 uv pip install -r requirements.txt


### PR DESCRIPTION
This fixes error `nvcc fatal   : Unsupported gpu architecture 'compute_110a'` when building `FLASHINFER_VERSION="0.4.0"` on Jetson Orin AGX  (sm 87) @johnnynunez 