### PR TITLE
Bugfix/Fix errors when building sglang/genai-bench

### DIFF
--- a/packages/llm/sglang/genai-bench/build.sh
+++ b/packages/llm/sglang/genai-bench/build.sh
@@ -22,9 +22,10 @@ echo "Building GENAI_BENCH"
 cd "${REPO_DIR}" || exit 1
 
 make install
-uv build --wheel --out-dir /opt --no-deps --verbose .
-uv pip install "${PIP_WHEEL_DIR}/genai-bench"*.whl
+uv build --wheel --out-dir /opt --verbose .
+uv pip install /opt/genai_bench*.whl
+
 cd "${REPO_DIR}" || exit 1
 
-twine upload --verbose "${PIP_WHEEL_DIR}/genai-bench"*.whl \
+twine upload --verbose ${PIP_WHEEL_DIR}/genai_bench*.whl \
   || echo "Failed to upload wheel to ${TWINE_REPOSITORY_URL:-<unset>}"


### PR DESCRIPTION
Got error when building sglang/genai-bench : `error: unexpected argument '--no-deps' found`  (the build process failed gracefully) .
Also there were problems with the wheel names, also fixed.