### PR TITLE
Bugfix/Add missing dependencies for building gdrcopy on ubuntu22 and cu126

### DIFF
--- a/packages/cuda/cudastack/build/build_gdrcopy.sh
+++ b/packages/cuda/cudastack/build/build_gdrcopy.sh
@@ -3,6 +3,16 @@ set -eux
 
 echo "Installing NVIDIA GDRCopy ${GDRCOPY_VERSION:-unknown} (GDRCopy)"
 
+# Install prerequisites
+apt-get update
+apt-get install -y \
+    dkms \
+    build-essential \
+    devscripts \
+    debhelper \
+    check \
+    libsubunit-dev
+
 # 1) Build .deb packages
 git clone --recursive https://github.com/NVIDIA/gdrcopy.git /opt/gdrcopy
 cd /opt/gdrcopy/packages


### PR DESCRIPTION
Building `gdrcopy:2.5.1` with `CUDA_VERSION=12.6 PYTHON_VERSION=3.10 LSB_RELEASE=22.0` failed due to missing libraies