### PR TITLE
Bugfix/Fix issues when building SGLang kernel on SM 87 (Jetson)

### DIFF
--- a/packages/pytorch/torchcodec/build.sh
+++ b/packages/pytorch/torchcodec/build.sh
@@ -8,7 +8,8 @@ apt-get install -y --no-install-recommends \
     git \
     pkg-config \
     libffi-dev \
-    libsndfile1
+    libsndfile1 \
+    python${PYTHON_VERSION}-dev
 
 rm -rf /var/lib/apt/lists/*
 apt-get clean


### PR DESCRIPTION
Fixed problem with build git clone logic and missing ARCH env var.
And added missing python dev lib that breaks building torchcodec:0.8.0 with python3.10/cu126