### PR TITLE
Bugfix/Add torch-memory-saver dependency

### DIFF
--- a/packages/llm/sglang/Dockerfile
+++ b/packages/llm/sglang/Dockerfile
@@ -2,7 +2,7 @@
 # name: sglang
 # group: llm
 # config: config.py
-# depends: [sgl-kernel]
+# depends: [sgl-kernel, torch-memory-saver]
 # requires: '>=36'
 # test: test.py
 # notes: https://github.com/sgl-project/sglang


### PR DESCRIPTION
When building SGLang on Jetson SM 87  + python3.10 + CUDA 12.6 , requires `torch-memory-saver>=0.0.9` but pypi.jetson-ai-lab.io/jp6/cu126 has 0.0.8