### PR TITLE
Bugfix/SGLang:0.5.5

### DIFF
--- a/packages/llm/sglang/config.py
+++ b/packages/llm/sglang/config.py
@@ -36,7 +36,7 @@ package = [
     sglang('0.4.4', '0.4.3.post2', default=False),
     sglang('0.4.6', '0.4.6', depends=['flashinfer:0.2.6.post1'], default=False),
     sglang('0.4.9', '0.4.9', depends=['flashinfer'], default=False),
-    sglang('0.5.3', '0.5.3', depends=['flashinfer', 'sgl-kernel:0.5.3'], default=False),
-    sglang('0.5.4', '0.5.4', depends=['flashinfer', 'sgl-kernel:0.5.4'], default=False), # Compatible with CUDA 13 (Spark and Thor)
-    sglang('0.5.5', '0.5.5', depends=['flashinfer', 'sgl-kernel:0.5.5'], default=True), # Compatible with CUDA 13 (Spark and Thor)
+    sglang('0.5.3', '0.5.3', depends=['flashinfer', 'sgl-kernel:0.5.3', 'torchao:0.9.0'], default=False),
+    sglang('0.5.4', '0.5.4', depends=['flashinfer', 'sgl-kernel:0.5.4', 'torchao:0.9.0'], default=False), # Compatible with CUDA 13 (Spark and Thor)
+    sglang('0.5.5', '0.5.5', depends=['flashinfer', 'sgl-kernel:0.5.5', 'torchao:0.9.0'], default=True), # Compatible with CUDA 13 (Spark and Thor)
 ]

--- a/packages/llm/sglang/sgl-kernel/config.py
+++ b/packages/llm/sglang/sgl-kernel/config.py
@@ -32,12 +32,13 @@ def sgl_kernel(version, branch=None, depends=None, default=False):
     return pkg, builder
 
 package = [
-    sgl_kernel('0.5.3', depends=['torchao:0.9.0'], default=False),
+    sgl_kernel('0.5.3', default=False),
     # Note: this version points to a specific commit at which the patch (sm_87-0.5.4.diff)
     # for CMakeLists.txt was created.
     # You can increase the branch/commit to get newer versions if there are no changes
     # in CMakeLists.txt at commit 88568c01eb99698eceef9a40b5f481e37c0b89d0
-    sgl_kernel('0.5.4', depends=['torchao:0.9.0'], default=False),
-    sgl_kernel('0.5.5', depends=['torchao:0.9.0'], default=False),
-    sgl_kernel('0.5.6', branch='main', default=True),
+    sgl_kernel('0.5.4', default=False),
+    sgl_kernel('0.5.5', default=False),
+    # Latest version from main branch.
+    sgl_kernel('latest', branch='main', default=True),
 ]


### PR DESCRIPTION
`jetson-containers build --simulate sglang:0.5.5` fails with : `KeyError: "couldn't find package:  sgl-kernel:0.5.5"`

Moved `torchao` dependency from `sgl-kernel` to `sglang` package, where it is actually required: https://github.com/sgl-project/sglang/blob/d5b6e50fe8148a851eb9170ced0208132596c615/python/pyproject.toml#L67

The latest SGLang should point to the latest `sgl-kernel`, they both use the same git branch

ping @johnnynunez 