### PR TITLE
Bugfix/vLLM: use correct flashinfer version

### DIFF
--- a/packages/attention/flashinfer/config.py
+++ b/packages/attention/flashinfer/config.py
@@ -39,5 +39,6 @@ package = [
     flash_infer('0.2.7', '0.2.7'),
     flash_infer('0.2.9', '0.2.9'),
     flash_infer('0.4.1', '0.4.1'),
-    flash_infer('0.5.2', '0.5.12', default=(CUDA_VERSION >= Version('12.6'))), # Thor compatibility
+    flash_infer('0.5.2', '0.5.2'), # Stable release
+    flash_infer('latest', 'main', default=(CUDA_VERSION >= Version('12.6'))), # Thor compatibility
 ]

--- a/packages/llm/vllm/config.py
+++ b/packages/llm/vllm/config.py
@@ -41,6 +41,6 @@ package = [
     vllm('0.10.2', depends=['flashinfer'], requires=['<=36', '<cu130'], default=False),
     vllm('0.11.0', depends=['flashinfer'], default=False),
     vllm('0.11.1', depends=['flashinfer:0.4.1'], default=True),
-    vllm('0.12.0', depends=['flashinfer:0.5.1'], default=False),
+    vllm('0.12.0', depends=['flashinfer:0.5.2'], default=False),
     vllm('0.13.0', depends=['flashinfer'], default=False),
 ]


### PR DESCRIPTION
There is no `flashinfer:0.5.1` in this leads to error when building `vllm:0.12.0`.
Looks like latest **stable** release is `0.5.2`.
I think we should have `flashinfer:latest` version pointing to **main** branch, which is the default version when building.
But I'm not sure if this could "break" some other logic with version check ( like < or > then version), if such logic exist   @johnnynunez 