### PR TITLE
Bugfix/Building sglang:0.5.5 (latest release) on Jetson (SM 87)

### DIFF
--- a/packages/llm/sglang/sgl-kernel/patches/sm_87-0.5.5.diff
+++ b/packages/llm/sglang/sgl-kernel/patches/sm_87-0.5.5.diff
@@ -1,6 +1,6 @@
 diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
---- a/sgl-kernel/CMakeLists.txt	(revision 1053e1be17ac1220acce874f80435d765c15aab9)
-+++ b/sgl-kernel/CMakeLists.txt	(date 1761458554519)
+--- a/sgl-kernel/CMakeLists.txt	(revision 0c006b8809cd99e1f95926401a2823dd952641c8)
++++ b/sgl-kernel/CMakeLists.txt	(date 1762618425067)
 @@ -136,10 +136,10 @@
  # Enable gencode below SM90
  option(ENABLE_BELOW_SM90 "Enable below SM90" ON)
@@ -25,7 +25,7 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
      "-std=c++17"
      "-DFLASHINFER_ENABLE_F16"
      "-DCUTE_USE_PACKED_TUPLE=1"
-@@ -219,50 +219,50 @@
+@@ -219,57 +219,57 @@
      )
  endif()
 
@@ -116,8 +116,20 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
 +    #)
  endif()
 
- if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_FP4)
-@@ -381,32 +381,34 @@
+-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_FP4)
+-    list(APPEND SGL_KERNEL_CUDA_FLAGS
+-        "-DENABLE_NVFP4=1"
+-    )
+-endif()
++#if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_FP4)
++#    list(APPEND SGL_KERNEL_CUDA_FLAGS
++#        "-DENABLE_NVFP4=1"
++#    )
++#endif()
+
+ # All source files
+ # NOTE: Please sort the filenames alphabetically
+@@ -379,20 +379,22 @@
      OUTPUT_NAME "common_ops"
      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/sm90"
  )
@@ -129,38 +141,14 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
 -Python_add_library(common_ops_sm100_build MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SOURCES})
 +# Python_add_library(common_ops_sm100_build MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SOURCES})
 
--target_compile_definitions(common_ops_sm100_build PRIVATE
--    USE_FAST_MATH=0
--)
 -target_compile_options(common_ops_sm100_build PRIVATE
 -    $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS}>
 -)
--target_include_directories(common_ops_sm100_build PRIVATE
--    ${repo-cutlass_SOURCE_DIR}/include
--    ${repo-cutlass_SOURCE_DIR}/tools/util/include
--    ${repo-flashinfer_SOURCE_DIR}/include
--    ${repo-flashinfer_SOURCE_DIR}/csrc
--    ${repo-mscclpp_SOURCE_DIR}/include
--    ${repo-cutlass_SOURCE_DIR}/examples/77_blackwell_fmha
--    ${repo-cutlass_SOURCE_DIR}/examples/common
--    ${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src
--)
-+#target_compile_definitions(common_ops_sm100_build PRIVATE
-+#    USE_FAST_MATH=0
-+#)
+-target_include_directories(common_ops_sm100_build PRIVATE ${INCLUDES})
 +#target_compile_options(common_ops_sm100_build PRIVATE
 +#    $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS}>
 +#)
-+#target_include_directories(common_ops_sm100_build PRIVATE
-+#    ${repo-cutlass_SOURCE_DIR}/include
-+#    ${repo-cutlass_SOURCE_DIR}/tools/util/include
-+#    ${repo-flashinfer_SOURCE_DIR}/include
-+#    ${repo-flashinfer_SOURCE_DIR}/csrc
-+#    ${repo-mscclpp_SOURCE_DIR}/include
-+#    ${repo-cutlass_SOURCE_DIR}/examples/77_blackwell_fmha
-+#    ${repo-cutlass_SOURCE_DIR}/examples/common
-+#    ${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src
-+#)
++#target_include_directories(common_ops_sm100_build PRIVATE ${INCLUDES})
  # Set output name and separate build directory to avoid conflicts
 -set_target_properties(common_ops_sm100_build PROPERTIES
 -    OUTPUT_NAME "common_ops"
@@ -173,16 +161,16 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
 
  find_package(Python3 COMPONENTS Interpreter REQUIRED)
  execute_process(
-@@ -433,7 +435,7 @@
-     ${CMAKE_CURRENT_BINARY_DIR}/mscclpp-build
+@@ -420,7 +422,7 @@
  )
+
  target_link_libraries(common_ops_sm90_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt mscclpp_static)
 -target_link_libraries(common_ops_sm100_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt mscclpp_static)
 +#target_link_libraries(common_ops_sm100_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt mscclpp_static)
 
  # sparse flash attention
  target_compile_definitions(common_ops_sm90_build PRIVATE
-@@ -441,17 +443,17 @@
+@@ -428,17 +430,17 @@
      FLASHATTENTION_DISABLE_DROPOUT
      FLASHATTENTION_DISABLE_UNEVEN_K
  )
@@ -204,9 +192,9 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
 -install(TARGETS common_ops_sm100_build LIBRARY DESTINATION sgl_kernel/sm100)
 +#install(TARGETS common_ops_sm100_build LIBRARY DESTINATION sgl_kernel/sm100)
 
- # ============================ Optional Install ============================= #
+ # ============================ Optional Install: FA3 ============================= #
  # set flash-attention sources file
-@@ -463,7 +465,7 @@
+@@ -450,7 +452,7 @@
          "-O3"
          "-Xcompiler"
          "-fPIC"
@@ -215,7 +203,7 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
          "-std=c++17"
          "-DCUTE_USE_PACKED_TUPLE=1"
          "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1"
-@@ -479,10 +481,10 @@
+@@ -466,10 +468,10 @@
      )
 
      if (ENABLE_BELOW_SM90)
@@ -230,9 +218,9 @@ diff --git a/sgl-kernel/CMakeLists.txt b/sgl-kernel/CMakeLists.txt
          # SM8X Logic
          file(GLOB FA3_SM8X_GEN_SRCS
              "${repo-flash-attention_SOURCE_DIR}/hopper/instantiations/flash_fwd_hdim*_sm80.cu")
-@@ -609,10 +611,10 @@
+@@ -596,10 +598,10 @@
 
- # flash attention 4
+ # ============================ Extra Install: FA4 ============================= #
  # TODO: find a better install condition.
 -if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
 -    # flash_attn/cute

--- a/packages/llm/sglang/test.py
+++ b/packages/llm/sglang/test.py
@@ -18,8 +18,10 @@ print('testing SGLang...')
 clear_memory()  # <-- Clean before anything else
 
 import sglang as sgl
-from sglang.check_env import check_env
 
-check_env()
+print(f"SGLang version: {sgl.__version__}")
+print(f"CUDA available: {torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"CUDA device: {torch.cuda.get_device_name(0)}")
 
 print('SGLang OK\n')


### PR DESCRIPTION
Updates to SGLang:0.5.5 patch  for Jetson SM 87 devices.
Also the check_env function was removed or renamed in SGLang 0.5.5, updated tests (tested with sglang:0.5.4 also)