### PR TITLE
vLLM: loosen flashinfer-python requirement to allow latest version.

### DIFF
--- a/packages/llm/vllm/build.sh
+++ b/packages/llm/vllm/build.sh
@@ -39,6 +39,11 @@ sed -i \
   -e 's|^xgrammar.*||g' \
   requirements/common.txt
 
+# Loosen flashinfer-python requirement to allow latest version.
+sed -i \
+  -e 's|^flashinfer-python.*|flashinfer-python|g' \
+  requirements/cuda.txt
+
 grep gguf requirements/common.txt
 
 


### PR DESCRIPTION
Latest vLLM requires `flashinfer-python==0.5.2`, this PR will remove the exact version requirement.