### PR TITLE
Bugfix/SGLang:0.5.6 - fix dependencies on Jetson SM 87

### DIFF
--- a/packages/attention/xformers/config.py
+++ b/packages/attention/xformers/config.py
@@ -1,12 +1,22 @@
-
 from jetson_containers import CUDA_VERSION
 from packaging.version import Version
+from ..pytorch.version import PYTORCH_VERSION
+from jetson_containers import update_dependencies
 
-def xformers(version, requires=None, default=True):
+
+def xformers(version, requires=None, pytorch=None, default=True):
     pkg = package.copy()
+
+    if pytorch:
+        pkg['depends'] = update_dependencies(pkg['depends'], f"pytorch:{pytorch}")
+    else:
+        pytorch = PYTORCH_VERSION
 
     if requires:
         pkg['requires'] = requires
+
+    if not isinstance(pytorch, Version):
+        pytorch = Version(pytorch)
 
     pkg['name'] = f'xformers:{version}'
 
@@ -19,15 +29,20 @@ def xformers(version, requires=None, default=True):
     builder['name'] = f'xformers:{version}-builder'
     builder['build_args'] = {**pkg['build_args'], **{'FORCE_BUILD': 'on'}}
 
-    if default:
+    if pytorch == PYTORCH_VERSION and default:
         pkg['alias'] = 'xformers'
         builder['alias'] = 'xformers:builder'
 
     return pkg, builder
 
+
 package = [
-    xformers('0.0.26', requires='<=cu122'),
-    xformers('0.0.29', requires='<cu126'), # support pytorch 2.5.1
-    xformers('0.0.30', default=(CUDA_VERSION < Version('12.6'))), # support pytorch 2.6.0
-    xformers('0.0.33', default=(CUDA_VERSION >= Version('12.6'))), # Support Blackwell and pytorch 2.7.0
+    xformers('0.0.26', pytorch='2.1', requires='<=cu122'),
+    xformers('0.0.29', pytorch='2.4', requires='<cu126'),  # support pytorch 2.5.1
+    xformers('0.0.30', pytorch='2.7', default=(CUDA_VERSION < Version('12.6'))),
+    # support pytorch 2.6.0
+    xformers('0.0.32.post2', pytorch='2.8', default=(CUDA_VERSION >= Version('12.6'))),
+    # support pytorch 2.8.0
+    xformers('0.0.33', default=(CUDA_VERSION >= Version('12.6'))),
+    # Support Blackwell and pytorch 2.9.0
 ]

--- a/packages/multimedia/ffmpeg/config.py
+++ b/packages/multimedia/ffmpeg/config.py
@@ -33,6 +33,7 @@ def ffmpeg(source, version=None, requires=None, default=False, alias=[]):
 
 package = [
   # ffmpeg('apt', default=True),
+  ffmpeg('git', version='7.1', alias=['ffmpeg:git'], default=False),
   ffmpeg('git', version='8.0', alias=['ffmpeg:git'], default=True),
   ffmpeg('jetpack', requires='==36.*'),
 ]

--- a/packages/pytorch/torchcodec/config.py
+++ b/packages/pytorch/torchcodec/config.py
@@ -2,7 +2,8 @@ from jetson_containers import update_dependencies
 from packaging.version import Version
 from ..pytorch.version import PYTORCH_VERSION
 
-def torchcodec(version, pytorch=None, requires=None):
+
+def torchcodec(version, pytorch=None, depends=None, requires=None):
     pkg = package.copy()
 
     pkg['name'] = f"torchcodec:{version.split('-')[0]}"  # remove any -rc* suffix
@@ -14,6 +15,9 @@ def torchcodec(version, pytorch=None, requires=None):
 
     if requires:
         pkg['requires'] = requires
+
+    if depends:
+        pkg['depends'] = update_dependencies(pkg['depends'], depends)
 
     if not isinstance(pytorch, Version):
         pytorch = Version(pytorch)
@@ -35,10 +39,11 @@ def torchcodec(version, pytorch=None, requires=None):
 
     return pkg, builder
 
+
 package = [
     # JetPack 5/6/7
-    torchcodec('0.6.0', pytorch='2.8', requires='>=36'),
-    torchcodec('0.7.0', pytorch='2.8', requires='>=36'),
+    torchcodec('0.6.0', pytorch='2.8', depends=['ffmpeg:7.1'], requires='>=36'),
+    torchcodec('0.7.0', pytorch='2.8', depends=['ffmpeg:7.1'], requires='>=36'),
     torchcodec('0.8.1', pytorch='2.9', requires='>=36'),
     torchcodec('0.8.1', pytorch='2.9.1', requires='>=36'),
     torchcodec('0.9.0', pytorch='2.10', requires='>=36'),


### PR DESCRIPTION
While building with `ENABLE_DISTRIBUTED_JETSON_NCCL=1 PYTORCH_FORCE_BUILD=on CUDA_VERSION=12.6 PYTHON_VERSION=3.10 LSB_RELEASE=22.04 PYTORCH_VERSION=2.8 jetson-containers build sglang:0.5.6` got error with: 

 - xformers 0.0.33 expectes torch:2.9 , so downgraded to 0.0.32.post2
 - using torch:2.8 mens building torchcodec:0.7.0 which fails to build because of default ffmpeg:8.0 , errors in https://github.com/meta-pytorch/torchcodec/blob/v0.7.0/src/torchcodec/_core/CMakeLists.txt#L280 ( `libavcodec_major_version` is `62`

@johnnynunez 