### PR TITLE
Bugfix/torchcodec - unique package names

### DIFF
--- a/packages/pytorch/torchcodec/config.py
+++ b/packages/pytorch/torchcodec/config.py
@@ -6,12 +6,12 @@ from ..pytorch.version import PYTORCH_VERSION
 def torchcodec(version, pytorch=None, depends=None, requires=None):
     pkg = package.copy()
 
-    pkg['name'] = f"torchcodec:{version.split('-')[0]}"  # remove any -rc* suffix
-
     if pytorch:
         pkg['depends'] = update_dependencies(pkg['depends'], f"pytorch:{pytorch}")
     else:
         pytorch = PYTORCH_VERSION
+    # Add pytorch version to package name for additional uniqueness.
+    pkg['name'] = f"torchcodec:{version.split('-')[0]}-pytorch:{pytorch}"  # remove any -rc* suffix
 
     if requires:
         pkg['requires'] = requires


### PR DESCRIPTION
Adds package name suffix to separate same versions with different PyTorch requirements.

Fix for https://github.com/dusty-nv/jetson-containers/issues/1514

@johnnynunez 