### PR TITLE
Bugfix/Error: "couldn't find package: jax" when building openpi #1525

### DIFF
--- a/packages/ml/jax/config.py
+++ b/packages/ml/jax/config.py
@@ -41,7 +41,8 @@ def jax(version, requires=None, alias=None, default=False):
 
 
 package = [
-    jax('0.4.38', requires='>=35'), # It works from jetpack 5 11.8 Cuda & 8.6 Cudnn
-    jax('0.6.2', requires='==36.*'), # It works from jetpack 5 11.8 Cuda & 8.6 Cudnn
+    # Note: each L4T version requirement must have at least a single default JAX version
+    jax('0.4.38', requires='==35.*', default=True), # It works from jetpack 5 11.8 Cuda & 8.6 Cudnn
+    jax('0.6.2', requires='==36.*', default=True), # It works from jetpack 5 11.8 Cuda & 8.6 Cudnn
     jax('0.8.1', requires='>=38', default=True), # Blackwell Support
 ]


### PR DESCRIPTION
There must be at least one default version per L4T version requirement, otherwise no available Jax package will be found for L4T r35/r36.
Fixes https://github.com/dusty-nv/jetson-containers/issues/1525
@johnnynunez 