### PR TITLE
Document distributed inference with vLLM on Jetson (SM_87)

### DIFF
--- a/docs/distributed-inference.md
+++ b/docs/distributed-inference.md
@@ -1,0 +1,238 @@
+## Distributed inference on Jetson devices
+
+### Available for NCCL v2.27.7 and L4T version 36.x
+
+Experimental support for distributed inference on Jetson devices that use NCCL v2.27.7 was added in this [PR](https://github.com/dusty-nv/jetson-containers/pull/1429).
+
+Supports Multi-node Parallelism using tensor parallel, as explained in[ vLLM's Multi-node deployment docs](https://docs.vllm.ai/en/stable/serving/parallelism_scaling.html#multi-node-deployment)
+
+### How to use:
+Build `PyTorch` from source with NCCL support enabled like this:
+
+```bash
+
+ENABLE_NCCL_DISTRIBUTED_JETSON=1 \
+PYTORCH_FORCE_BUILD=on \
+jetson-containers build pytorch
+```
+Or if building `vLLM`:
+
+```bash
+
+ENABLE_NCCL_DISTRIBUTED_JETSON=1 \
+PYTORCH_FORCE_BUILD=on \
+jetson-containers build vllm
+```
+
+#### This will:
+- build `NCCL` with the patch that adds support for Jetson
+- build `PyTorch` with `USE_SYSTEM_NCCL` enabled
+
+
+### Running on 2 Jetson devices:
+
+#### Example with 2x `Jetson Orin AGX 64 GB RAM` dev kits
+Below there are 2 ways to run distributed inference on 2 Jetson devices:
+1. Manual docker method: running docker containers and starting Ray on both devices (requires docker knowledge)
+2. Using the helper script at `./distributed-inference.sh` (easier), just skip the `Manual docker method` below if using this method
+
+- In this example one Jetson is referenced as `HEAD NODE` and the other as `WORKER NODE`
+- Tested with images:
+  - `mitakad/vllm:0.12.0-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated`
+  - `mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated`
+
+#### 1. Manual docker method:
+- On the `HEAD NODE`, first get the IP address of the device and the network interface name to be used for communication (e.g. `eno1`, `eth0`, etc):
+  - `VLLM_HOST_IP` is the IP address of the `HEAD NODE`
+  - `VLLM_IFNAME` is the network interface name to be used for communication on `HEAD NODE`
+  - `HF_TOKEN` is your Hugging Face token if you are using models from Hugging Face Hub
+  - `JETSON_CONTAINERS_PATH` is the path where jetson-containers repo is stored on `HEAD NODE`
+  - Then run the container with the following command, first replacing the `...` with the appropriate values:
+```bash
+VLLM_HOST_IP=... && \
+VLLM_IFNAME=... && \
+HF_TOKEN=... && \
+docker run --runtime nvidia -it \
+--network host \
+--shm-size=8g \
+--privileged \
+--ipc=host \
+-v /dev/shm:/dev/shm \
+-v $(jetson-containers data):/data \
+-e NVIDIA_DRIVER_CAPABILITIES=all \
+-e VLLM_HOST_IP=${VLLM_HOST_IP} \
+-e UCX_NET_DEVICES=${VLLM_IFNAME} \
+-e NCCL_SOCKET_IFNAME=${VLLM_IFNAME} \
+-e GLOO_SOCKET_IFNAME=${VLLM_IFNAME} \
+-e TP_SOCKET_IFNAME=${VLLM_IFNAME} \
+-e TIKTOKEN_ENCODINGS_BASE=/data/encodings \
+-e HF_TOKEN=${HF_TOKEN} \
+--name vllm_112_eth \
+mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated
+```
+- On the `WORKER NODE` run same command as above but this time set the variables accordingly:
+  - `VLLM_HOST_IP` is the IP address of the `WORKER NODE`
+  - `VLLM_IFNAME` is the network interface name to be used for communication on `WORKER NODE`
+  - `HF_TOKEN` is your Hugging Face token if you are using models from Hugging Face Hub
+  - `JETSON_CONTAINERS_PATH` is the path where jetson-containers repo is stored on `WORKER NODE`
+
+- Next we need to start Ray on both devices ([What is Ray?](https://docs.vllm.ai/en/latest/serving/parallelism_scaling/#what-is-ray))
+  - On the `HEAD NODE` container run (replace values in `{{}}`):
+```bash
+ray start -v --block --head --port 6379 --node-ip-address {{ set HEAD NODE IP here}} --num-gpus 1
+```
+  - On the `WORKER NODE` container run (replace values in `{{}}`):
+```bash
+ray start -v --block --address {{ set HEAD NODE IP here }}:6379 --node-ip-address {{ set WORKER NODE IP here }} --num-gpus 1
+```
+
+- Finally, on the `HEAD NODE` container run the following command to start distributed inference (replace values in `{{}}`):
+```bash
+vllm serve Qwen/Qwen3-4B-Instruct-2507-FP8 --port 8000 \
+    --served-model-name Qwen3-4B-Instruct-2507-FP8 \
+    --max-model-len 2048 \
+    --max-num-batched-tokens 2048 \
+    --gpu-memory-utilization 0.5 \
+    --max-num-seqs 10 \
+    --tensor-parallel-size 2
+```
+
+- You can now send requests to the `HEAD NODE` IP address on port `8000` to perform distributed inference across both Jetson devices:
+- Example using `curl`:
+```bash
+curl --location 'http://{{ set HEAD NODE IP here}}:8000/v1/chat/completions' \
+--header 'Content-Type: application/json' \
+--data '{
+            "model": "Qwen3-4B-Instruct-2507-FP8",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Avast! What'\''s the future of AI?"
+                }
+            ]
+        }'
+```
+
+#### 2. Helper script to run distributed inference on 2 Jetson devices at `./distributed-inference.sh`
+
+Below is an example of how to use the helper script.
+
+For `HEAD NODE` IP address we use `192.168.1.100`.
+
+For `WORKER NODE` IP address we use `192.168.1.101`.
+
+Using network interface `eno1` for communication.
+
+- On `HEAD NODE`:
+    1. This is the command <u>without</u> the example values filled in:
+    ```bash
+        bash distributed-inference.sh \
+             mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated \
+             <HEAD NODE IP> \
+             --head  \
+             <network_interface> \
+             -e VLLM_HOST_IP=<HEAD NODE IP> \
+             -e HF_TOKEN=<huggingface_token>
+    ```
+
+    2. This is the command <u>with</u> the example values filled in:
+
+    ```bash
+    bash distributed-inference.sh \
+        mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated \
+        192.168.1.100 \
+        --head \
+        eno1 \
+        -e VLLM_HOST_IP=192.168.1.100 \
+        -e HF_TOKEN=hf_xxx
+    ```
+
+- On `WORKER NODE`:
+
+    1. This is the command <u>without</u> the example values filled in:
+    ```bash
+        bash distributed-inference.sh \
+             mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated \
+             <HEAD NODE IP> \
+             --worker  \
+             <network_interface> \
+             -e VLLM_HOST_IP=<WORKER NODE IP> \
+             -e HF_TOKEN=<huggingface_token>
+    ```
+
+    2. This is the command <u>with</u> the example values filled in:
+    ```bash
+    bash distributed-inference.sh \
+        mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated \
+        192.168.1.100 \
+        --worker \
+        eno1 \
+        -e VLLM_HOST_IP=192.168.1.101 \
+        -e HF_TOKEN=hf_xxx
+    ```
+
+- Then start the distributed inference on the `HEAD NODE` container:
+  1. example command for `gpt-oss-20b` (~ 12 t/s on 10 Gbit connection):
+
+    ```bash
+    docker exec -it jetson-cluster-node \
+    vllm serve openai/gpt-oss-20b --port 8000 \
+        --served-model-name gpt-oss-20b \
+        --max-model-len 2048 \
+        --max-num-batched-tokens 2048 \
+        --gpu-memory-utilization 0.5 \
+        --kv-cache-memory-bytes 3000M \
+        --max-num-seqs 10 \
+        --tensor-parallel-size 2 \
+        --enable-expert-parallel \
+        --distributed-executor-backend ray
+    ```
+
+  2. example command for `gpt-oss-120b` (~ 9 t/s on 10 Gbit connection):
+
+    ```bash
+    docker exec -it jetson-cluster-node \
+    vllm serve openai/gpt-oss-120b --port 8000 \
+        --served-model-name gpt-oss-120b \
+        --max-model-len 2048 \
+        --max-num-batched-tokens 2048 \
+        --kv-cache-memory-bytes 3000M \
+        --max-num-seqs 10 \
+        --tensor-parallel-size 2 \
+        --enable-expert-parallel \
+        --distributed-executor-backend ray
+    ```
+  3. example command for `QuantTrio/GLM-4.5-Air-AWQ-FP16Mix` (~ 6 t/s on 10 Gbit connection):
+
+    ```bash
+    docker exec -it jetson-cluster-node \
+    vllm serve QuantTrio/GLM-4.5-Air-AWQ-FP16Mix --port 8000 \
+        --served-model-name GLM-4.5-Air-AWQ-FP16Mix \
+        --max-model-len 2048 \
+        --max-num-batched-tokens 2048 \
+        --kv-cache-memory-bytes 6000M \
+        --max-num-seqs 10 \
+        --tensor-parallel-size 2 \
+        --enable-expert-parallel \
+        --distributed-executor-backend ray
+    ```
+  
+- Test with `curl` (replace values in `{{}}`):
+```bash
+curl --location 'http://{{ set HEAD NODE IP here}}:8000/v1/chat/completions' \
+--header 'Content-Type: application/json' \
+--data '{
+            "model": "{{ served-model-name }}",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Why is the sky blue?"
+                }
+            ]
+        }'
+```
+
+### Notes:
+The existing ethernet connection speed between the Jetson devices will impact performance. 
+Faster connection will provide better performance.
+You could use PCIe ports to connect NICs to get better connection speeds (over 10 Gbit/s).

--- a/docs/distributed-inference.sh
+++ b/docs/distributed-inference.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+# Launch a Ray cluster inside Docker for vLLM inference on Jetson devices.
+#
+# Usage:
+# 1. On head node:
+#    bash run_jetson_cluster.sh \
+#         mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated \
+#         <head_node_ip> \
+#         --head \
+#         <network_interface> \
+#         -e VLLM_HOST_IP=<head_node_ip> \
+#         -e HF_TOKEN=<token>
+#
+# 2. On each worker node:
+#    bash run_jetson_cluster.sh \
+#         mitakad/vllm:0.11.2-r36.4.tegra-aarch64-cp310-cu126-22.04-truncated \
+#         <head_node_ip> \
+#         --worker \
+#         <network_interface> \
+#         -e VLLM_HOST_IP=<worker_node_ip> \
+#         -e HF_TOKEN=<token>
+
+if [ $# -lt 5 ]; then
+    echo "Usage: $0 docker_image head_node_ip --head|--worker network_interface [additional_args...]"
+    exit 1
+fi
+
+DOCKER_IMAGE="$1"
+HEAD_NODE_ADDRESS="$2"
+NODE_TYPE="$3"
+NETWORK_INTERFACE="$4"
+shift 4
+
+ADDITIONAL_ARGS=("$@")
+
+echo "=========================================="
+echo "DEBUG: Script Arguments"
+echo "=========================================="
+echo "DOCKER_IMAGE: ${DOCKER_IMAGE}"
+echo "HEAD_NODE_ADDRESS: ${HEAD_NODE_ADDRESS}"
+echo "NODE_TYPE: ${NODE_TYPE}"
+echo "NETWORK_INTERFACE: ${NETWORK_INTERFACE}"
+echo "ADDITIONAL_ARGS: ${ADDITIONAL_ARGS[@]}"
+echo ""
+
+if [ "${NODE_TYPE}" != "--head" ] && [ "${NODE_TYPE}" != "--worker" ]; then
+    echo "Error: Node type must be --head or --worker"
+    exit 1
+fi
+
+CONTAINER_NAME="jetson-cluster-node"
+
+cleanup() {
+    docker stop "${CONTAINER_NAME}"
+    docker rm "${CONTAINER_NAME}"
+}
+trap cleanup EXIT
+
+# Build Ray start command
+RAY_START_CMD="ray start -v --block --num-gpus 1"
+if [ "${NODE_TYPE}" == "--head" ]; then
+    RAY_START_CMD+=" --head --port=6379 --num-gpus 1"
+else
+    RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379 --num-gpus 1"
+fi
+
+echo "=========================================="
+echo "DEBUG: Ray Configuration"
+echo "=========================================="
+echo "RAY_START_CMD: ${RAY_START_CMD}"
+echo ""
+
+# Parse VLLM_HOST_IP from additional args
+VLLM_HOST_IP=""
+for arg in "${ADDITIONAL_ARGS[@]}"; do
+    if [[ $arg == "-e" ]]; then
+        continue
+    fi
+    if [[ $arg == VLLM_HOST_IP=* ]]; then
+        VLLM_HOST_IP="${arg#VLLM_HOST_IP=}"
+        break
+    fi
+done
+
+echo "=========================================="
+echo "DEBUG: Parsed Variables"
+echo "=========================================="
+echo "VLLM_HOST_IP: ${VLLM_HOST_IP}"
+echo ""
+
+# Build Ray IP environment variables if VLLM_HOST_IP is set
+RAY_IP_VARS=()
+if [ -n "${VLLM_HOST_IP}" ]; then
+    RAY_IP_VARS=(
+        -e "RAY_NODE_IP_ADDRESS=${VLLM_HOST_IP}"
+        -e "RAY_OVERRIDE_NODE_IP_ADDRESS=${VLLM_HOST_IP}"
+    )
+fi
+
+echo "=========================================="
+echo "DEBUG: Ray IP Variables"
+echo "=========================================="
+echo "RAY_IP_VARS: ${RAY_IP_VARS[@]}"
+echo ""
+
+# Get jetson-containers data path
+JETSON_DATA_PATH="$(jetson-containers data)"
+
+echo "=========================================="
+echo "DEBUG: Paths"
+echo "=========================================="
+echo "JETSON_DATA_PATH: ${JETSON_DATA_PATH}"
+echo ""
+
+echo "=========================================="
+echo "DEBUG: Full Docker Command"
+echo "=========================================="
+echo "docker run \\"
+echo "    --runtime nvidia \\"
+echo "    --entrypoint /bin/bash \\"
+echo "    --network host \\"
+echo "    --name \"${CONTAINER_NAME}\" \\"
+echo "    --shm-size 8g \\"
+echo "    --privileged \\"
+echo "    --ipc=host \\"
+echo "    -v /dev/shm:/dev/shm \\"
+echo "    -v ${JETSON_DATA_PATH}:/data \\"
+echo "    -e NVIDIA_DRIVER_CAPABILITIES=all \\"
+echo "    -e UCX_NET_DEVICES=${NETWORK_INTERFACE} \\"
+echo "    -e NCCL_SOCKET_IFNAME=${NETWORK_INTERFACE} \\"
+echo "    -e GLOO_SOCKET_IFNAME=${NETWORK_INTERFACE} \\"
+echo "    -e TP_SOCKET_IFNAME=${NETWORK_INTERFACE} \\"
+echo "    -e TIKTOKEN_ENCODINGS_BASE=/data/encodings \\"
+for var in "${RAY_IP_VARS[@]}"; do
+    echo "    ${var} \\"
+done
+for arg in "${ADDITIONAL_ARGS[@]}"; do
+    echo "    ${arg} \\"
+done
+echo "    \"${DOCKER_IMAGE}\" -c \"${RAY_START_CMD}\""
+echo ""
+
+echo "=========================================="
+echo "Press Enter to execute, Ctrl+C to cancel"
+echo "=========================================="
+read
+
+# Launch container with Jetson-specific configurations
+docker run \
+    --runtime nvidia \
+    --entrypoint /bin/bash \
+    --network host \
+    --name "${CONTAINER_NAME}" \
+    --shm-size 8g \
+    --privileged \
+    --ipc=host \
+    -v /dev/shm:/dev/shm \
+    -v $(jetson-containers data):/data \
+    -e NVIDIA_DRIVER_CAPABILITIES=all \
+    -e UCX_NET_DEVICES=${NETWORK_INTERFACE} \
+    -e NCCL_SOCKET_IFNAME=${NETWORK_INTERFACE} \
+    -e GLOO_SOCKET_IFNAME=${NETWORK_INTERFACE} \
+    -e TP_SOCKET_IFNAME=${NETWORK_INTERFACE} \
+    -e TIKTOKEN_ENCODINGS_BASE=/data/encodings \
+    "${RAY_IP_VARS[@]}" \
+    "${ADDITIONAL_ARGS[@]}" \
+    "${DOCKER_IMAGE}" -c "${RAY_START_CMD}"


### PR DESCRIPTION
- Added description how to build images with enabled distributed inference with `NCCL:v2.27.7` and `vLLM` (with `Ray`).

- Added helper script for easy of use of the images and configuration required.

- Based on guide from vLLM's docs: https://docs.vllm.ai/en/latest/serving/parallelism_scaling/#ray-cluster-setup-with-containers 

@johnnynunez 