### PR TITLE
Fix `cudastack` for JetPack 5.

### DIFF
--- a/packages/cuda/cudastack/config.py
+++ b/packages/cuda/cudastack/config.py
@@ -54,8 +54,8 @@ def cuda_stack_args():
                 tensorrt_url = f"{tensorrt_base_url}/10.0.1/tars/TensorRT-10.0.1.6.l4t.aarch64-gnu.cuda-12.4.tar.gz"
             nccl_ver = '2.27.7'
         else:  # JetPack 5
-            cudnn_ver = '8.9.4'
-            cudnn_url = "https://nvidia.box.com/shared/static/ht4li6b0j365ta7b76a6gw29rk5xh8cy.deb"
+            cudnn_ver = '8.6.0'
+            cudnn_url = "https://repo.download.nvidia.com/jetson/common/pool/main/c/cudnn/libcudnn8_8.6.0.166-1+cuda11.4_arm64.deb"
             cudnn_packages = "libcudnn8 libcudnn8-dev"
             tensorrt_ver = '8.6.0'
             tensorrt_url = "https://nvidia.box.com/shared/static/hmwr57hm88bxqrycvlyma34c3k4c53t9.deb"
@@ -170,13 +170,13 @@ if IS_TEGRA and IS_CONFIG:
         cuda_stack('cudastack:minimal',
                    with_tensorrt=False,
                    minimal=True,
-                   requires='>=36'),
+                   requires='>=35'),
 
         # Standard: + TensorRT and all CUDA libraries
         cuda_stack('cudastack:standard',
                    with_tensorrt=True,
                    minimal=False,
-                   requires='>=36'),
+                   requires='>=35'),
     ]
 
 elif IS_SBSA and IS_CONFIG:


### PR DESCRIPTION
My JetPack 5 has CUDNN 8.6.0 installed.

```
dpkg -l | grep cudnn
ii  libcudnn8                                                   8.6.0.166-1+cuda11.4                 arm64        cuDNN runtime libraries
ii  libcudnn8-dev                                               8.6.0.166-1+cuda11.4                 arm64        cuDNN development libraries and headers
ii  libcudnn8-samples                                           8.6.0.166-1+cuda11.4                 arm64        cuDNN samples
```

I have confirmed that using an image built from these changes, I was able to compile PyTorch 2.3.1 from source with CUDNN support enabled:

```
>>> import torch
>>> torch.version
<module 'torch.version' from '/installation/.venv/lib/python3.10/site-packages/torch/version.py'>
>>> torch.__version__
'2.3.1'
>>> torch.cuda.is_available()
True
>>> torch.backends.cudnn.is_available()
True
>>> torch.backends.cudnn.version()
8600
```