### PR TITLE
Feature/Open-WebUI with Ollama and CUDA support

### DIFF
--- a/packages/llm/open-webui/Dockerfile
+++ b/packages/llm/open-webui/Dockerfile
@@ -1,0 +1,189 @@
+#---
+# name: open-webui
+# alias: openwebui
+# group: llm
+# config: config.py
+# depends: [python, pytorch, torchvision, torchaudio, ctranslate2]
+#---
+ARG BASE_IMAGE
+
+ARG OPEN_WEBUI_VERSION
+
+# syntax=docker/dockerfile:1
+# Initialize device type args
+# use build args in the docker build command with --build-arg="BUILDARG=true"
+ARG USE_CUDA=true
+ARG USE_OLLAMA=false
+# Tested with cu117 for CUDA 11 and cu121 for CUDA 12 (default)
+ARG USE_CUDA_VER=CUDA_VERSION
+# any sentence transformer model; models to use can be found at https://huggingface.co/models?library=sentence-transformers
+# Leaderboard: https://huggingface.co/spaces/mteb/leaderboard
+# for better performance and multilangauge support use "intfloat/multilingual-e5-large" (~2.5GB) or "intfloat/multilingual-e5-base" (~1.5GB)
+# IMPORTANT: If you change the embedding model (sentence-transformers/all-MiniLM-L6-v2) and vice versa, you aren't able to use RAG Chat with your previous documents loaded in the WebUI! You need to re-embed them.
+ARG USE_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+ARG USE_RERANKING_MODEL=""
+
+# Tiktoken encoding name; models to use can be found at https://huggingface.co/models?library=tiktoken
+ARG USE_TIKTOKEN_ENCODING_NAME="cl100k_base"
+
+ARG BUILD_HASH=dev-build
+# Override at your own risk - non-root configurations are untested
+ARG UID=0
+ARG GID=0
+
+######## WebUI frontend ########
+FROM node:22-alpine3.20 AS build
+ARG BUILD_HASH
+ARG OPEN_WEBUI_VERSION
+
+# to store git revision in build
+RUN apk add --no-cache git
+
+RUN git clone --branch v${OPEN_WEBUI_VERSION} --recursive --depth=1 https://github.com/open-webui/open-webui /app
+
+WORKDIR /app
+
+# Apply patch for specific requirements
+RUN sed -i -e's/faster-whisper==1.1.1/faster-whisper==1.1.1.post1/' backend/requirements.txt pyproject.toml
+
+RUN npm install -g npm@latest && npm ci --force
+
+ENV APP_BUILD_HASH=${BUILD_HASH}
+RUN npm run build
+
+######## WebUI backend ########
+FROM ${BASE_IMAGE} AS base
+
+# Use args
+ARG USE_CUDA
+ARG USE_OLLAMA
+ARG USE_CUDA_VER
+ARG USE_EMBEDDING_MODEL
+ARG USE_RERANKING_MODEL
+ARG UID
+ARG GID
+ARG JETSON_JETPACK
+
+## Basis and Ollama defaults that you can override with passing -v VARIABLE_NAME=value to docker run command ##
+ENV ENV=prod \
+    PORT=8080 \
+    USE_OLLAMA_DOCKER=${USE_OLLAMA} \
+    USE_CUDA_DOCKER=${USE_CUDA} \
+    USE_CUDA_DOCKER_VER=${USE_CUDA_VER} \
+    USE_EMBEDDING_MODEL_DOCKER=${USE_EMBEDDING_MODEL} \
+    USE_RERANKING_MODEL_DOCKER=${USE_RERANKING_MODEL} \
+    JETSON_JETPACK=${JETSON_JETPACK} \
+    OLLAMA_LOGS=/data/logs/ollama.log \
+    OLLAMA_MODELS=/data/models/ollama \
+    OLLAMA_FLASH_ATTENTION=true \
+    OLLAMA_KEEP_ALIVE=15m
+
+## Basis URL Config ##
+ENV OLLAMA_BASE_URL="/ollama" \
+    OPENAI_API_BASE_URL=""
+
+## API Key and Security Config ##
+ENV OPENAI_API_KEY="" \
+    WEBUI_SECRET_KEY="" \
+    SCARF_NO_ANALYTICS=true \
+    DO_NOT_TRACK=true \
+    ANONYMIZED_TELEMETRY=false
+
+#### Other models #########################################################
+## whisper TTS model settings ##
+ENV WHISPER_MODEL="base" \
+    WHISPER_MODEL_DIR="/app/backend/data/cache/whisper/models"
+
+## RAG Embedding model settings ##
+ENV RAG_EMBEDDING_MODEL="$USE_EMBEDDING_MODEL_DOCKER" \
+    RAG_RERANKING_MODEL="$USE_RERANKING_MODEL_DOCKER" \
+    SENTENCE_TRANSFORMERS_HOME="/app/backend/data/cache/embedding/models"
+
+## Tiktoken model settings ##
+ENV TIKTOKEN_ENCODING_NAME="cl100k_base" \
+    TIKTOKEN_CACHE_DIR="/app/backend/data/cache/tiktoken"
+
+## Hugging Face download cache ##
+ENV HF_HOME="/app/backend/data/cache/embedding/models"
+
+## Torch Extensions ##
+# ENV TORCH_EXTENSIONS_DIR="/.cache/torch_extensions"
+
+#### Other models ##########################################################
+
+WORKDIR /app/backend
+
+ENV HOME=/root
+# Create user and group if not root
+RUN if [ $UID -ne 0 ]; then \
+    if [ $GID -ne 0 ]; then \
+    addgroup --gid $GID app; \
+    fi; \
+    adduser --uid $UID --gid $GID --home $HOME --disabled-password --no-create-home app; \
+    fi
+
+RUN mkdir -p $HOME/.cache/chroma
+RUN echo -n 00000000-0000-0000-0000-000000000000 > $HOME/.cache/chroma/telemetry_user_id
+
+# Make sure the user has access to the app and root directory
+RUN chown -R $UID:$GID /app $HOME
+
+# Install common system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git build-essential pandoc gcc netcat-openbsd curl jq \
+    python3-dev \
+    ffmpeg libsm6 libxext6 \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy backend requirements before installing python deps
+COPY --chown=$UID:$GID --from=build /app/backend/requirements.txt ./requirements.txt
+
+# install python dependencies and validate install of some packages
+RUN uv pip install --system -r requirements.txt --no-cache-dir && \
+    mkdir -p /app/backend/data && chown -R $UID:$GID /app/backend/data/
+
+RUN python3 -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['RAG_EMBEDDING_MODEL'], device='cuda')" && \
+    python3 -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cuda', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
+    python3 -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])";
+
+# Install Ollama if requested
+RUN if [ "$USE_OLLAMA" = "true" ]; then \
+    date +%s > /tmp/ollama_build_hash && \
+    echo "Cache broken at timestamp: `cat /tmp/ollama_build_hash`" && \
+    curl -fsSL https://ollama.com/install.sh | sh && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# copy embedding weight from build
+# RUN mkdir -p /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2
+# COPY --from=build /app/onnx /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx
+
+# copy built frontend files
+COPY --chown=$UID:$GID --from=build /app/build /app/build
+COPY --chown=$UID:$GID --from=build /app/CHANGELOG.md /app/CHANGELOG.md
+COPY --chown=$UID:$GID --from=build /app/package.json /app/package.json
+
+# copy backend files
+COPY --chown=$UID:$GID --from=build /app/backend .
+
+EXPOSE 8080
+
+HEALTHCHECK CMD curl --silent --fail http://localhost:${PORT:-8080}/health | jq -ne 'input.status == true' || exit 1
+
+# Minimal, atomic permission hardening for OpenShift (arbitrary UID):
+# - Group 0 owns /app and /root
+# - Directories are group-writable and have SGID so new files inherit GID 0
+RUN set -eux; \
+    chgrp -R 0 /app /root || true; \
+    chmod -R g+rwX /app /root || true; \
+    find /app -type d -exec chmod g+s {} + || true; \
+    find /root -type d -exec chmod g+s {} + || true
+
+USER $UID:$GID
+
+ARG BUILD_HASH
+ENV WEBUI_BUILD_VERSION=${BUILD_HASH}
+ENV DOCKER=true
+
+CMD [ "bash", "start.sh"]

--- a/packages/llm/open-webui/README.md
+++ b/packages/llm/open-webui/README.md
@@ -1,0 +1,25 @@
+### Open WebUI with CUDA Support for Jetson
+
+- Example build command for CUDA 12.6 on Jetson with Ubuntu 22.04, Python 3.10, and PyTorch 2.9.1:
+  - Pass `USE_OLLAMA=on` (or `USE_OLLAMA=true` or `USE_OLLAMA=1` ) as an environment variable to build Ollama in the same container.
+
+```bash
+LSB_RELEASE=22.04 CUDA_VERSION=12.6 PYTHON_VERSION=3.10 PYTORCH_VERSION=2.9.1 USE_OLLAMA=on jetson-containers build open-webui
+```
+
+- Example build command for CUDA 12.9 on Jetson with Ubuntu 24.04, Python 3.12, and PyTorch 2.9.1:
+  - Pass `USE_OLLAMA=on` as the example above to build Ollama in the same container.
+
+```bash
+LSB_RELEASE=24.04 CUDA_VERSION=12.9 PYTHON_VERSION=3.12 PYTORCH_VERSION=2.9.1 USE_OLLAMA=on jetson-containers build open-webui
+  ```
+
+- Example run command:
+  - Map a persistent directory on the host to `/app/backend/data` in the container to store database and settings.
+  - Other env params can be passed if needed, like `OLLAMA_KEEP_ALIVE=15m` or `OLLAMA_CONTEXT_LENGTH=32000`: 
+
+```bash
+jetson-containers run -v /path/to/your/open-webui/persistent/dir:/app/backend/data open-webui
+```
+
+- After Open WebUI starts, access it via `http://<jetson-ip>:8080` in your web browser.

--- a/packages/llm/open-webui/config.py
+++ b/packages/llm/open-webui/config.py
@@ -1,0 +1,70 @@
+import os
+
+from jetson_containers import JETPACK_VERSION
+
+
+def get_latest_release_tag(repo_path):
+    """Get the latest release tag from a GitHub repository.
+
+    Args:
+        repo_path: GitHub repo path like user/repo
+
+    Returns:
+        str: Latest release tag name
+    """
+
+    # Call GitHub API
+    api_url = f"https://api.github.com/repos/{repo_path}/releases/latest"
+    import requests
+    response = requests.get(api_url)
+
+    if response.status_code == 200:
+        return response.json()['tag_name']
+    else:
+        raise Exception(
+            f"Failed to fetch release from {api_url} : {response.status_code} - {response.text}")
+
+
+def open_webui(version, repo=None, requires=None, default=False):
+    if repo and version == 'stable':
+        version = get_latest_release_tag(repo)
+        # strip the starting v if exists
+        if version.startswith('v'):
+            version = version[1:]
+
+    pkg = package.copy()
+
+    if requires:
+        pkg['requires'] = requires
+
+    pkg['name'] = f'open-webui:{version}'
+    use_ollama = os.environ.get('USE_OLLAMA', 'false')
+    if use_ollama.lower() == 'true' or use_ollama == '1' or use_ollama.lower() == 'on':
+        use_ollama = 'true'
+    else:
+        use_ollama = 'false'
+
+    pkg['build_args'] = {
+        'OPEN_WEBUI_VERSION': version,
+        'USE_CUDA': 'true',
+        'BUILDPLATFORM': 'linux/arm64',
+        # Passing 'USE_OLLAMA=true' to install ollama client in the same image as webui.
+        # Usage: USE_OLLAMA=true jetson-containers build open-webui
+        'USE_OLLAMA': use_ollama,
+        'JETSON_JETPACK': JETPACK_VERSION.major,
+    }
+
+    builder = pkg.copy()
+
+    builder['name'] = f'open-webui:{version}-builder'
+
+    if default:
+        pkg['alias'] = 'open-webui'
+        builder['alias'] = 'open-webui:builder'
+
+    return pkg, builder
+
+
+package = [
+    open_webui('stable', repo='open-webui/open-webui',default=True),
+]


### PR DESCRIPTION
Dockerfile copied from the official [Dockerfile](https://github.com/open-webui/open-webui/blob/main/Dockerfile) with additional modifications to work with `jetson-continers` .

Ollama can be built in the same container.

Check readme to build and run.

There is only one "tag" to be build instead of versioning, and it's the "stable" one, meaning it will always build the latest stable release tag, currently [v0.6.41](https://github.com/open-webui/open-webui/releases/tag/v0.6.41)