### PR TITLE
Added feature: enables ROS2 security when its being build from source

### DIFF
--- a/packages/robots/ros/ros2_build.sh
+++ b/packages/robots/ros/ros2_build.sh
@@ -30,7 +30,7 @@ print_log " ROS2 $ROS_DISTRO installer ($(uname -m))
 # ------------------------------------------------------------------------------
 apt-get update
 apt-get install -y --no-install-recommends \
-  curl wget gnupg2 lsb-release ca-certificates
+  curl wget gnupg2 lsb-release ca-certificates libssl-dev
 
 curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
   -o /usr/share/keyrings/ros-archive-keyring.gpg
@@ -246,7 +246,8 @@ colcon build \
   --cmake-args \
   -Wno-dev -Wno-deprecated \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_POLICY_DEFAULT_CMP0148=OLD
+  -DCMAKE_POLICY_DEFAULT_CMP0148=OLD \
+  -DSECURITY=ON
   # -DCMAKE_WARN_DEPRECATED=OFF
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
With respect to the issue #1595, we wanted to enable the [ROS2 security](https://docs.ros.org/en/rolling/Tutorials/Advanced/Security/Introducing-ros2-security.html) features in your containers.

According to the ROS2 [docs](https://docs.ros.org/en/iron/Tutorials/Advanced/Security/Introducing-ros2-security.html#installing-from-source), openssl would need to be available and the colcon build command would need to include the CMake argument --cmake-args -DSECURITY=ON.

So made the following two modifications in ros2_build.sh:

add libssl-dev to the apt install command [here](https://github.com/shekharsingh8811/jetson-containers/blob/feature/enable-ros2-security-issue%231595/packages/robots/ros/ros2_build.sh#L33)
add -DSECURITY=ON to the colcon build command [here](https://github.com/shekharsingh8811/jetson-containers/blob/feature/enable-ros2-security-issue%231595/packages/robots/ros/ros2_build.sh#L244)

We are currently using dustynv/ros:humble-desktop-l4t-r36.4.0 and expect the change in the repo automatically triggers a rebuild and a newer version of this release with ROS2 security enabled.

Closes issue #1595