### PR TITLE
Update cutlass default version condition to include CUDA 12.6

### DIFF
--- a/packages/cuda/cutlass/config.py
+++ b/packages/cuda/cutlass/config.py
@@ -25,6 +25,6 @@ def cutlass(version, version_spec=None, requires=None, default=False):
     return pkg, builder
 
 package = [
-    cutlass('3.9.2', default=(CUDA_VERSION < Version('12.6'))),
+    cutlass('3.9.2', default=(CUDA_VERSION <= Version('12.6'))),
     cutlass('4.4.0', default=(CUDA_VERSION >= Version('13.0'))),
 ]


### PR DESCRIPTION
i had a problem when trying to build vllm image on jetson orin nx :

`KeyError: "couldn't find package:  cutlass"`

This fix should be sufficient.