### PR TITLE
Bugfix/Remove relative import paths

### DIFF
--- a/packages/attention/xformers/config.py
+++ b/packages/attention/xformers/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import CUDA_VERSION
 from packaging.version import Version
-from ..pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 from jetson_containers import update_dependencies
 
 

--- a/packages/cv/jetson-inference/config.py
+++ b/packages/cv/jetson-inference/config.py
@@ -1,4 +1,4 @@
-from ..robots.ros.version import ROS2_DISTROS
+from packages.physicalAI.ros.version import ROS2_DISTROS
 
 package['name'] = 'jetson-inference:main'
 package['alias'] = 'jetson-inference'
@@ -7,12 +7,12 @@ package = [package]
 
 for distro in ROS2_DISTROS:
     ros = package[0].copy()
- 
+
     ros['name'] = f'jetson-inference:{distro}'
     ros['depends'] = [f'ros:{distro}-desktop', 'jetson-inference:main']
     ros['dockerfile'] = 'Dockerfile.ros'
     ros['test'] = ros['test'] + ['test_ros.sh']
-    
+
     del ros['alias']
     package.append(ros)
 

--- a/packages/hw/zed/config.py
+++ b/packages/hw/zed/config.py
@@ -2,7 +2,7 @@
 from jetson_containers import L4T_VERSION, CUDA_VERSION, LSB_RELEASE, IS_TEGRA
 from packaging.version import Version
 
-from ..robots.ros import ros_container
+from packages.physicalAI.ros import ros_container
 
 def zed(version, l4t_version=None, requires=None, default=False):
     """
@@ -19,7 +19,7 @@ def zed(version, l4t_version=None, requires=None, default=False):
         url = f"https://download.stereolabs.com/zedsdk/{version}/l4t{l4t_version}/jetsons"
     else:
         url = f"https://download.stereolabs.com/zedsdk/{version}/cu{CUDA_VERSION.major}/ubuntu{LSB_RELEASE.split('.')[0]}"
-    
+
     sdk['build_args'] = {
         'ZED_URL': url,
         'L4T_MAJOR_VERSION': L4T_VERSION.major,
@@ -41,7 +41,7 @@ def zed(version, l4t_version=None, requires=None, default=False):
             **sdk,
             'name': sdk['name'] + '-${ROS_DISTRO}',
             'alias': sdk['alias'] + '-${ROS_DISTRO}',
-            }, 
+            },
             'https://github.com/stereolabs/zed-ros2-interfaces',
             'https://github.com/stereolabs/zed-ros2-wrapper',
             distros=['humble', 'jazzy'], base_packages='desktop'

--- a/packages/ml/pytorch/torchaudio/config.py
+++ b/packages/ml/pytorch/torchaudio/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies
 from packaging.version import Version
-from ..ml.pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 
 def torchaudio(version, pytorch=None, requires=None):
     pkg = package.copy()

--- a/packages/ml/pytorch/torchcodec/config.py
+++ b/packages/ml/pytorch/torchcodec/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies
 from packaging.version import Version
-from ..ml.pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 
 
 def torchcodec(version, pytorch=None, depends=None, requires=None):

--- a/packages/ml/pytorch/torchsde/config.py
+++ b/packages/ml/pytorch/torchsde/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies
 from packaging.version import Version
-from ..ml.pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 
 def torchsde(version, pytorch=None, requires=None):
     pkg = package.copy()

--- a/packages/ml/pytorch/torchtext/config.py
+++ b/packages/ml/pytorch/torchtext/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies
 from packaging.version import Version
-from ..ml.pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 
 def torchtext(version, pytorch=None, requires=None):
     pkg = package.copy()

--- a/packages/ml/pytorch/torchvision/config.py
+++ b/packages/ml/pytorch/torchvision/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies
 from packaging.version import Version
-from ..ml.pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 
 def torchvision(version, pytorch=None, requires=None):
     pkg = package.copy()

--- a/packages/ml/tensorflow/config.py
+++ b/packages/ml/tensorflow/config.py
@@ -1,8 +1,8 @@
 from jetson_containers import L4T_VERSION, PYTHON_VERSION, CUDA_VERSION, IS_SBSA
 from packaging.version import Version
 
-from ..ml.tensorflow.version import TENSORFLOW_VERSION
-from ..cuda.cudastack.config import CUDNN_VERSION
+from packages.ml.tensorflow.version import TENSORFLOW_VERSION
+from packages.cuda.cudastack.config import CUDNN_VERSION
 
 
 def tensorflow(version, tensorflow_version='tf2', requires=None, default=False):

--- a/packages/ml/tensorflow/graphics/config.py
+++ b/packages/ml/tensorflow/graphics/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies, PYTHON_VERSION
 from packaging.version import Version
-from ..ml.tensorflow.version import TENSORFLOW_VERSION
+from packages.ml.tensorflow.version import TENSORFLOW_VERSION
 
 def tensorflow_graphics(version, tensorflow=None, requires=None):
     pkg = package.copy()

--- a/packages/ml/tensorflow/text/config.py
+++ b/packages/ml/tensorflow/text/config.py
@@ -1,6 +1,6 @@
 from jetson_containers import update_dependencies, PYTHON_VERSION
 from packaging.version import Version
-from ..ml.tensorflow.version import TENSORFLOW_VERSION
+from packages.ml.tensorflow.version import TENSORFLOW_VERSION
 
 def tensorflow_text(version, tensorflow=None, requires=None):
     pkg = package.copy()

--- a/packages/ml/triton/config.py
+++ b/packages/ml/triton/config.py
@@ -1,4 +1,4 @@
-from ..ml.pytorch.version import PYTORCH_VERSION
+from packages.ml.pytorch.version import PYTORCH_VERSION
 from packaging.version import Version
 
 def triton(version, branch=None, requires=None, default=False):

--- a/packages/physicalAI/isaac-ros/config.py
+++ b/packages/physicalAI/isaac-ros/config.py
@@ -1,5 +1,5 @@
 from jetson_containers import L4T_VERSION, LSB_RELEASE
-from ..physicalAI.ros import ros_container, ROS_DISTROS
+from packages.physicalAI.ros import ros_container, ROS_DISTROS
 
 ISAAC_ROS_URL="https://github.com/NVIDIA-ISAAC-ROS"
 

--- a/packages/physicalAI/ros/config.py
+++ b/packages/physicalAI/ros/config.py
@@ -1,5 +1,5 @@
 from jetson_containers import L4T_VERSION, PYTHON_VERSION
-from ..physicalAI.ros import ROS_DISTROS, ROS2_DISTROS, ROS_PACKAGES, ros_container
+from packages.physicalAI.ros import ROS_DISTROS, ROS2_DISTROS, ROS_PACKAGES, ros_container
 
 import copy
 


### PR DESCRIPTION
Relates to #1633 
Fixes errors like: `ModuleNotFoundError: No module named 'packages.pytorch'` 
@johnnynunez 