### PR TITLE
Bugfix/flash_attn_cute wheel not found after build on Jetson Orin AGX

### DIFF
--- a/packages/attention/flash-attention/build.sh
+++ b/packages/attention/flash-attention/build.sh
@@ -51,7 +51,7 @@ uv build --wheel . -v --no-build-isolation --out-dir /opt/flash-attention/wheels
 ls /opt
 cd /
 
-uv pip install /opt/flash-attention/wheels/flash_attn*.whl
+uv pip install /opt/flash-attention/wheels/flash_attn-*.whl
 #pip3 show flash-attn && python3 -c 'import flash_attn'
 
 #FlashAttention4 , cute requires cutlass 4.3.0
@@ -59,6 +59,6 @@ uv pip install /opt/flash-attention/wheels/flash_attn*.whl
 echo "Building FlashAttention4 (cute) ${FLASH_ATTENTION_VERSION}"
 cd /opt/flash-attention/flash_attn/cute
 uv build --wheel . -v --no-build-isolation --out-dir /opt/flash-attention/wheels
-uv pip install /opt/flash-attention/wheels/flash_attn*.whl
+uv pip install /opt/flash-attention/wheels/flash_attn_*.whl || echo "Failed to install FlashAttention4(a CuTeDSL-based implementation for Hopper and Blackwell GPUs)"
 
 twine upload --verbose /opt/flash-attention/wheels/flash_attn*.whl || echo "failed to upload wheel to ${TWINE_REPOSITORY_URL}"


### PR DESCRIPTION
```
DOCKER_BUILDKIT=0 docker build --network=host --shm-size=8g \
  --tag vllm:0.16.1-r36.5.tegra-aarch64-cp312-cu129-24.04-flash-attention \
  --file /home/mitaka/jetson-containers/packages/attention/flash-attention/Dockerfile \
  --build-arg BASE_IMAGE=vllm:0.16.1-r36.5.tegra-aarch64-cp312-cu129-24.04-cutlass \
  --build-arg NVIDIA_DRIVER_CAPABILITIES=all \
  --build-arg FLASH_ATTENTION_VERSION="3.0.0" \
  --build-arg IS_SBSA="False" \
   /home/mitaka/jetson-containers/packages/attention/flash-attention
   ```
   After building successfully the packages, got error:
   ```
   Successfully built /opt/flash-attention/wheels/flash_attn_4-0.0.0-py3-none-any.whl
   + uv pip install '/opt/flash-attention/wheels/flash_attn_cute*.whl'
   Using Python 3.12.13 environment at: /opt/venv
   error: The wheel filename "flash_attn_cute*.whl" is invalid: Must have a version
   ```
@johnnynunez 