### PR TITLE
Bugfix/Use ffmpeg's nv-codec-headers from github

### DIFF
--- a/packages/multimedia/ffmpeg/build.sh
+++ b/packages/multimedia/ffmpeg/build.sh
@@ -73,7 +73,7 @@ pkg-config --modversion aom
 pkg-config --modversion SvtAv1Enc
 
 # nv-codec-headers
-git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+git clone https://github.com/FFmpeg/nv-codec-headers.git
 cd nv-codec-headers && make PREFIX="$DIST" install
 
 export PATH=/usr/local/cuda/bin:${PATH}


### PR DESCRIPTION
Building FFMPEG 8.0 on Jetson Orin AGX fails with:
```
+ git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
Cloning into 'nv-codec-headers'...
fatal: unable to access 'https://git.videolan.org/git/ffmpeg/nv-codec-headers.git/': The requested URL returned error: 502
```
Instead use GitHub repo https://github.com/FFmpeg/nv-codec-headers.git  , official mirror of the VideoLAN path
@johnnynunez 