### PR TITLE
Bugfix/Correct version of video codec SDK

### DIFF
--- a/packages/multimedia/video-codec-sdk/config.py
+++ b/packages/multimedia/video-codec-sdk/config.py
@@ -30,5 +30,5 @@ def video_codec_sdk(version, default=False):
 
 package = [
   video_codec_sdk('12.2.72'),
-  video_codec_sdk('13.0.37', default=True)
+  video_codec_sdk('13.0.19', default=True)
 ]


### PR DESCRIPTION
The failure to find the specified video_codec_sdk version caused tensorrt_edgellm to compile on jetson orin agx.

I don't know why the apt server doesn't have video_codec_sdk 13.0.37?