### PR TITLE
Bugfix/Correct onnxruntime version

### DIFF
--- a/packages/ml/onnxruntime/build.sh
+++ b/packages/ml/onnxruntime/build.sh
@@ -81,7 +81,14 @@ uv pip uninstall onnxruntime || echo "onnxruntime was not previously installed"
 git clone https://github.com/microsoft/onnxruntime /opt/onnxruntime
 cd /opt/onnxruntime
 
-git checkout ${ONNXRUNTIME_BRANCH} || echo "Branch ${ONNXRUNTIME_BRANCH} not found, staying on main branch"
+if git checkout ${ONNXRUNTIME_BRANCH}; then
+    echo "Checked out ${ONNXRUNTIME_BRANCH}"
+elif git checkout v${ONNXRUNTIME_VERSION}; then
+    echo "Branch ${ONNXRUNTIME_BRANCH} not found, checked out tag v${ONNXRUNTIME_VERSION}"
+else
+    echo "ERROR: failed to checkout branch ${ONNXRUNTIME_BRANCH} or tag v${ONNXRUNTIME_VERSION}"
+    exit 1
+fi
 git submodule update --init --recursive
 
 install_dir="/opt/onnxruntime/install"

--- a/packages/ml/onnxruntime/config.py
+++ b/packages/ml/onnxruntime/config.py
@@ -37,7 +37,7 @@ def onnxruntime(version, branch=None, requires=None, default=False):
 
 
 package = [
-    onnxruntime('1.25.0', requires=['>=36', '>=cu126'], branch='rel-1.25.0', default=(CUDA_VERSION >= Version('12.6'))),
+    onnxruntime('1.24.3', requires=['>=36', '>=cu126'], branch='rel-1.24.3', default=(CUDA_VERSION >= Version('12.6'))),
     onnxruntime('1.24.1', requires=['>=36', '>=cu126'], branch='rel-1.24.1', default=False),
     onnxruntime('1.23.2', requires=['>=36', '>=cu126'], branch='rel-1.23.2', default=False),
     onnxruntime('1.22', requires=['>=36', '>=cu126'], branch='rel-1.22.0', default=False),


### PR DESCRIPTION
I found that the latest version of onnxruntime upstream is 1.24.3, why is the 1.25.0 in the code written in the code?Is it to accumulate a wave of upstream updates and upload again?

I modified the version to build the latest version, do you think it needs to be?