### PR TITLE
vLLM Orin-specific FA3 patch

### DIFF
--- a/packages/llm/vllm/patches/generate_diff.py
+++ b/packages/llm/vllm/patches/generate_diff.py
@@ -352,6 +352,43 @@ def _fetch_fa_cmake(repo_url, git_tag):
     return None
 
 
+def modify_fa_cmake_fa3_orin(content: str) -> str:
+    """
+    Enable FA3 for Orin (sm87) in the vendored flash-attention CMakeLists.txt.
+
+    * Flips ``FA3_ENABLED`` from OFF to ON (or inserts it after FA2_ENABLED).
+    * Forces the FA3 ``cuda_archs_loose_intersection`` call to use the same
+      target arch as FA2 (normally gated at 9.0a / Hopper-only).
+    """
+    cuda_val = _cuda_arch_cmake_value()
+
+    # ── 1. Set FA3_ENABLED ON ────────────────────────────────────────────
+    if re.search(r'\bset\s*\(\s*FA3_ENABLED\s+OFF\s*\)', content):
+        content = re.sub(
+            r'\bset\s*\(\s*FA3_ENABLED\s+OFF\s*\)',
+            'set(FA3_ENABLED ON)',
+            content,
+        )
+    elif not re.search(r'\bset\s*\(\s*FA3_ENABLED\s+ON\s*\)', content):
+        # No FA3_ENABLED line at all – insert one after FA2_ENABLED
+        content = re.sub(
+            r'(set\s*\(\s*FA2_ENABLED\s+ON\s*\))',
+            r'\1\nset(FA3_ENABLED ON)',
+            content,
+        )
+
+    # ── 2. Force FA3 arch intersection to the target arch ─────────────────
+    # The upstream CMake guards FA3 at "9.0a" (Hopper); override to target
+    # so that Orin (sm87) is included.
+    content = re.sub(
+        r'(cuda_archs_loose_intersection\s*\(\s*FA3_ARCHS\s+)"[^"]*"',
+        rf'\1"{cuda_val}"',
+        content,
+    )
+
+    return content
+
+
 def generate_fa_diff(base_dir, diff_dir):
     """Produce ``fa.diff`` for the vendored flash-attention CMakeLists.txt."""
     cmake_path = os.path.join(
@@ -368,6 +405,9 @@ def generate_fa_diff(base_dir, diff_dir):
         return False
 
     modified = modify_cmake_archs(original)
+    # Only apply the Orin-specific FA3 patch.
+    if _cuda_arch_cmake_value() == "8.7":
+        modified = modify_fa_cmake_fa3_orin(modified)
     diff_text = _unified_diff(original, modified, "CMakeLists.txt")
     if not diff_text:
         print("flash-attention CMakeLists.txt: no changes needed")


### PR DESCRIPTION
@johnnynunez  To continue the conversation from #1671.

This PR enables FA3 in the `fa.diff` patch, based on `vllm-project/flash-attention`.
Tested building vllm and it looks to build the vLLM package and then install/run it.

```
-- Build type: RelWithDebInfo
-- Target device: cuda
-- Found Python: /opt/venv/bin/python (found version "3.12.13") found components: Interpreter Development.Module Development.SABIModule
-- CUDA target architectures: 8.7
-- CUDA supported target architectures: 8.7
-- FA2_ARCHS: 8.7
-- FA3_ARCHS: 8.7
-- vllm-flash-attn is available at /opt/vllm/.deps/vllm-flash-attn-src
-- Configuring done (147.0s)
-- Generating done (0.1s)
-- Build files have been written to: /opt/vllm/build/temp.linux-aarch64-cpython-312
Using NVCC_THREADS=1 as the number of nvcc threads.
Change Dir: '/opt/vllm/build/temp.linux-aarch64-cpython-312'

Run Build Command(s): /opt/venv/bin/ninja -v -j 12 _moe_C cumem_allocator triton_kernels _vllm_fa2_C _vllm_fa3_C _vllm_fa4_cutedsl_C _flashmla_C _flashmla_extension_C _C _C_stable_libtorch
[1/335]
```

The tests show :
```
(EngineCore pid=104) INFO 04-09 15:20:33 [gpu_model_runner.py:4735] Starting to load model facebook/opt-125m...
(EngineCore pid=104) INFO 04-09 15:20:34 [cuda.py:334] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=104) INFO 04-09 15:20:34 [flash_attn.py:596] Using FlashAttention version 2
```
Looks like vLLM still falls-back to FA2..
Will run another build with FA3 only enabled when building.