### PR TITLE
Bugfix/Build missing (on install) cutlass packages

### DIFF
--- a/packages/cuda/cutlass/install.sh
+++ b/packages/cuda/cutlass/install.sh
@@ -6,7 +6,7 @@ if [ "$FORCE_BUILD" == "on" ]; then
 	exit 1
 fi
 
-uv pip install --no-cache-dir nvidia-cutlass==${CUTLASS_VERSION} pycute --prerelease=allow || echo "failed to install nvidia-cutlass for Python ${PYTHON_VERSION}"
+uv pip install --no-cache-dir nvidia-cutlass==${CUTLASS_VERSION} pycute --prerelease=allow || { echo "failed to install nvidia-cutlass for Python ${PYTHON_VERSION}"; exit 1; }
 
 # if #PYTHON_VERSION == "3.12" then install the DSL version
 echo "Installing nvidia-cutlass-dsl for Python 3.12"


### PR DESCRIPTION
While building image for `CUTLASS_VERSION="4.4.2"`:

```
Step 5/6 : COPY build.sh install.sh /tmp/cutlass/
 ---> 3d6c1f94c1da
Step 6/6 : RUN /tmp/cutlass/install.sh || /tmp/cutlass/build.sh
 ---> Running in 1bc3500587ce
+ '[' off == on ']'
+ uv pip install --no-cache-dir nvidia-cutlass==4.4.2 pycute --prerelease=allow
Using Python 3.12.13 environment at: /opt/venv
  × No solution found when resolving dependencies:
  ╰─▶ Because there is no version of nvidia-cutlass==4.4.2 and you require
      nvidia-cutlass==4.4.2, we can conclude that your requirements are
      unsatisfiable.
failed to install nvidia-cutlass for Python 3.12
Installing nvidia-cutlass-dsl for Python 3.12
+ echo 'failed to install nvidia-cutlass for Python 3.12'
+ echo 'Installing nvidia-cutlass-dsl for Python 3.12'
+ uv pip install nvidia-cutlass-dsl --prerelease=allow
Using Python 3.12.13 environment at: /opt/venv
Resolved 7 packages in 13.22s
Downloading nvidia-cutlass-dsl-libs-base (72.0MiB)
 Downloaded nvidia-cutlass-dsl-libs-base
Prepared 2 packages in 7.04s
Installed 2 packages in 14ms
 + nvidia-cutlass-dsl==4.5.0.dev0
 + nvidia-cutlass-dsl-libs-base==4.5.0.dev0
 ---> Removed intermediate container 1bc3500587ce
 ---> b7b47e40cae6
[Warning] One or more build-args [NVIDIA_DRIVER_CAPABILITIES] were not consumed
Successfully built b7b47e40cae6
```

Added `exit 1` so the build process continues with `build.sh` when the python package is missing from index.

@johnnynunez 

