### PR TITLE
Container security improvements: multi-stage builds, non-root user, secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,17 @@ jetson-containers run $(autotag <package>) [command]
 
 # Find the best matching image tag (local → DockerHub → build)
 autotag <package>
+
+# Useful build flags
+jetson-containers build --simulate <package>              # dry-run: print commands without building
+jetson-containers build --multiple pytorch tensorflow     # build each package as a separate image
+jetson-containers build --list-packages                   # list all discovered packages
+jetson-containers build --show-packages <package>         # show resolved metadata for a package
+jetson-containers build --base=xyz:latest <package>       # start the build chain from an existing image
+jetson-containers build --push=myuser <package>           # push to a registry after building
+
+# Check for upstream version upgrades (--apply to write changes)
+jetson-containers upgrade [<package> ...] [--apply]
 ```
 
 ### Code Style
@@ -34,7 +45,13 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-Pre-commit runs **Black** (formatter, line-length=88) and **Flake8** (linter) on `jetson_containers/`, `packages/example/`, and `test_precommit.py`. Note: `skip-string-normalization = true` in `pyproject.toml`.
+Pre-commit runs **Black** (formatter, line-length=88) and **Flake8** (linter) only on `jetson_containers/` and `test_precommit.py`. `packages/` Dockerfiles and `config.py` files are **not** linted by pre-commit. Note: `skip-string-normalization = true` in `pyproject.toml`.
+
+### Tests
+```bash
+# Run a package config unit test directly (uses stdlib unittest, no pytest needed)
+python3 tests/verify_triton_config.py
+```
 
 ### Installation
 ```bash
@@ -65,6 +82,20 @@ Key metadata fields: `name`, `alias`, `depends` (build-order deps), `requires` (
 
 `config.py` files execute at build time and can return multiple package dicts to produce version variants. For example, PyTorch's `config.py` generates `pytorch:2.8`, `pytorch:2.8-all`, `pytorch:2.8-builder`, etc. Aliases (`torch` → `pytorch:2.8`) are resolved during package discovery.
 
+When a package's version selection logic is complex, put it in a separate `version.py` alongside `config.py`. This lets other packages cross-import it:
+```python
+from packages.ml.pytorch.version import PYTORCH_VERSION
+```
+The `_PackagesFinder` meta path finder in `packages.py` resolves these imports against the `packages/` tree without requiring `__init__.py` files.
+
+### Dockerfile Conventions
+
+Use `uv pip install` (not plain `pip install`) inside Dockerfiles — `uv` is pre-installed in the base images and is significantly faster. Every Dockerfile must start with:
+```dockerfile
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+```
+
 ### Version Overrides
 
 Copy `.env.default` → `.env` to override `L4T_VERSION`, `CUDA_VERSION`, `LSB_RELEASE`, `CUDA_ARCH`, local PyPI/APT mirror URLs, and SCP/webhook credentials without modifying tracked files.
@@ -76,6 +107,101 @@ Copy `.env.default` → `.env` to override `L4T_VERSION`, `CUDA_VERSION`, `LSB_R
 3. Optionally add `test.py` or `test.sh` for post-build validation.
 4. Build: `jetson-containers build <name>`
 
+## Security Features
+
+### Multi-Stage Builds
+
+The build system is multi-stage aware. Packages can use `FROM ... AS <alias>` for intermediate stages (e.g. a compiler/builder stage) without those stages polluting the final image. The build system tracks stage boundaries and only injects BuildKit features (ccache env vars, `--device` mounts, ccache `--mount` flags) into the **final** stage (the `FROM ${BASE_IMAGE}` stage). Intermediate stages are left untouched.
+
+Declare multi-stage packages in config metadata:
+```yaml
+#---
+# name: mypackage
+# multistage: true
+# depends: [cuda]
+#---
+ARG BASE_IMAGE
+FROM gcc:12 AS builder
+RUN make install
+
+FROM ${BASE_IMAGE}
+COPY --from=builder /usr/local /usr/local
+RUN ldconfig
+```
+
+The final stage **must** use `ARG BASE_IMAGE` / `FROM ${BASE_IMAGE}` so it chains correctly in the dependency build pipeline.
+
+### Non-Root User
+
+**At build time** — pass identity via env vars; packages can create and switch to the declared user:
+```bash
+export CONTAINER_USER=jetson
+export CONTAINER_UID=1000
+export CONTAINER_GID=1000
+jetson-containers build mypackage
+```
+
+`CONTAINER_USER`, `CONTAINER_UID`, `CONTAINER_GID` are forwarded as `--build-arg` automatically. Packages consume them like:
+```dockerfile
+ARG CONTAINER_USER=root
+ARG CONTAINER_UID=0
+ARG CONTAINER_GID=0
+RUN if [ "$CONTAINER_UID" != "0" ]; then \
+        groupadd -g $CONTAINER_GID $CONTAINER_USER && \
+        useradd -u $CONTAINER_UID -g $CONTAINER_GID -m $CONTAINER_USER; \
+    fi
+USER $CONTAINER_USER
+```
+
+Declare the supported user in package metadata (`run_user` is informational for tooling):
+```yaml
+# run_user: jetson
+```
+
+**At runtime** — set `DOCKER_USER` to run the container as a non-root identity:
+```bash
+DOCKER_USER=1000:1000 ./run.sh myimage
+# or by name (the user must exist in the image):
+DOCKER_USER=jetson ./run.sh myimage
+```
+X11 forwarding (`xhost`) is automatically updated to grant the declared user display access.
+
+### Secrets
+
+**Build-time secrets** (never baked into image layers) — declare secrets in package metadata:
+```yaml
+#---
+# name: mypackage
+# secrets: [huggingface_token]
+#---
+```
+
+Point each secret at a file on the host via `JETSON_SECRET_<NAME>`:
+```bash
+export JETSON_SECRET_HUGGINGFACE_TOKEN=~/.hf_token
+jetson-containers build mypackage
+```
+
+Secrets are mounted as `/run/secrets/<name>` inside `RUN` steps only (BuildKit `--secret`). Use them in the Dockerfile:
+```dockerfile
+RUN --mount=type=secret,id=huggingface_token \
+    HF_TOKEN=$(cat /run/secrets/huggingface_token) \
+    python3 download_model.py
+```
+
+If the env var is missing, a warning is printed and the build continues without that secret.
+
+**Runtime secrets** — prefer file-backed tokens over env vars (values in env vars are visible in `docker inspect`):
+```bash
+# Preferred: mount token file into /run/secrets/
+HUGGINGFACE_TOKEN_FILE=~/.hf_token ./run.sh myimage
+
+# Fallback (token visible in docker inspect):
+HUGGINGFACE_TOKEN=hf_xxx ./run.sh myimage
+```
+
+`HUGGINGFACE_TOKEN_FILE` mounts the file read-only at `/run/secrets/huggingface_token` and sets `HF_TOKEN_FILE` inside the container.
+
 ### Key Supporting Modules
 
 - `jetson_containers/tag.py` — image tagging conventions
@@ -83,3 +209,5 @@ Copy `.env.default` → `.env` to override `L4T_VERSION`, `CUDA_VERSION`, `LSB_R
 - `jetson_containers/ci.py` — CI/CD helpers
 - `jetson_containers/network.py` / `webhook.py` — GitHub API integration and build notifications
 - `jetson_containers/logging.py` — colored terminal output used throughout
+- `jetson_containers/upgrade.py` — checks packages against upstream (PyPI/GitHub) for newer versions; powers `jetson-containers upgrade`
+- `jetson_containers/db.py` — syncs DockerHub/GitHub metadata for registry introspection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,8 @@ DOCKER_USER=jetson ./run.sh myimage
 ```
 X11 forwarding (`xhost`) is automatically updated to grant the declared user display access.
 
+For GPU access, `run.sh` also discovers the numeric GIDs that own the NVIDIA/Tegra device nodes (`/dev/nvhost*`, `/dev/nvmap`, `/dev/nvgpu/*`, `/dev/dri/render*`) and adds them via `--group-add <gid>`. Without this, a non-root process can't open the GPU nodes and CUDA fails with error 801 (`cudaGetDeviceCount` "operation not supported"). Numeric GIDs are used because the host's `render` GID usually doesn't match the container's. See [`docs/run.md`](/docs/run.md#gpu-access-as-non-root-cuda-error-801).
+
 ### Secrets
 
 **Build-time secrets** (never baked into image layers) — declare secrets in package metadata:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+# Contributing to jetson-containers
+
+## Adding a Package
+
+1. Create `packages/<category>/<name>/` and add a `Dockerfile` with a `#---` YAML header:
+
+   ```dockerfile
+   #---
+   # name: mypackage
+   # group: ml
+   # depends: [pytorch, cuda]
+   # requires: '>=36'
+   # test: test.py
+   #---
+   ARG BASE_IMAGE
+   FROM ${BASE_IMAGE}
+
+   RUN uv pip install mypackage
+   ```
+
+2. **Every Dockerfile must start with `ARG BASE_IMAGE` / `FROM ${BASE_IMAGE}`** so it chains correctly in the dependency build pipeline.
+
+3. **Use `uv pip install`** (not plain `pip install`) — `uv` is pre-installed in base images and is significantly faster.
+
+4. Run a local build to verify: `jetson-containers build mypackage`
+
+5. Add a `test.py` or `test.sh` that imports or exercises the package — it runs automatically after build unless `--skip-tests` is passed.
+
+Full metadata reference: [`docs/packages.md`](/docs/packages.md)
+
+## Multi-Stage Packages
+
+If your Dockerfile uses intermediate build stages, declare `multistage: true` in the header so tooling knows:
+
+```dockerfile
+#---
+# name: mypackage
+# multistage: true
+# depends: [cuda]
+#---
+ARG BASE_IMAGE
+FROM gcc:12 AS builder
+RUN make -j$(nproc) && make install DESTDIR=/out
+
+FROM ${BASE_IMAGE}
+COPY --from=builder /out /usr/local
+RUN ldconfig
+```
+
+The build system only injects ccache and GPU device mounts into the **final** `FROM ${BASE_IMAGE}` stage. Intermediate stages are left untouched.
+
+## Non-Root Support
+
+If your package is designed to run as a non-root user, accept the standard identity build args and declare `run_user` in metadata:
+
+```dockerfile
+#---
+# name: mypackage
+# run_user: jetson
+#---
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG CONTAINER_USER=root
+ARG CONTAINER_UID=0
+ARG CONTAINER_GID=0
+
+RUN if [ "$CONTAINER_UID" != "0" ]; then \
+        groupadd -g $CONTAINER_GID $CONTAINER_USER && \
+        useradd -u $CONTAINER_UID -g $CONTAINER_GID -m $CONTAINER_USER; \
+    fi
+
+USER $CONTAINER_USER
+```
+
+Build with: `CONTAINER_USER=jetson CONTAINER_UID=1000 CONTAINER_GID=1000 jetson-containers build mypackage`
+
+> **Note:** Packages that use CSI cameras via `nvargus-daemon` cannot support non-root — the daemon socket is root-owned by design.
+
+## Secrets
+
+If your package needs credentials at build time (model weights, private registries), declare them in metadata and consume via BuildKit `--mount=type=secret`:
+
+```dockerfile
+#---
+# name: mypackage
+# secrets: [huggingface_token]
+#---
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN --mount=type=secret,id=huggingface_token \
+    HF_TOKEN=$(cat /run/secrets/huggingface_token) \
+    python3 download_weights.py
+```
+
+The caller sets `JETSON_SECRET_HUGGINGFACE_TOKEN=/path/to/token/file` before building. The secret is never baked into an image layer.
+
+## Dynamic Version Configs
+
+Use `config.py` when package variants or build args depend on the L4T/CUDA/Python version. Put version-selection logic in a separate `version.py` so other packages can import it:
+
+```python
+# packages/ml/mypackage/version.py
+from jetson_containers import L4T_VERSION, CUDA_VERSION
+from packaging.version import Version
+
+MYPACKAGE_VERSION = Version('2.0') if L4T_VERSION.major >= 36 else Version('1.8')
+```
+
+Other packages can then do: `from packages.ml.mypackage.version import MYPACKAGE_VERSION`
+
+## Code Style
+
+Changes to `jetson_containers/` Python files must pass Black and Flake8:
+
+```bash
+pip install -r requirements.txt
+pre-commit install          # one-time setup
+pre-commit run --all-files  # check before committing
+```
+
+- **Black** line length: 88 (`skip-string-normalization = true` — single quotes are fine)
+- **Flake8** covers `jetson_containers/` only; `packages/` Dockerfiles and `config.py` files are not linted
+
+## Testing
+
+Run unit tests with stdlib `unittest` (no pytest needed):
+
+```bash
+python3 tests/verify_triton_config.py
+```
+
+For new packages, a `test.py` that does a minimal import + sanity check is sufficient. The build system runs it automatically after the package builds.
+
+## Pull Request Guidelines
+
+- **One logical change per PR** — new package, security feature, bug fix, or doc update.
+- **All changes to `jetson_containers/`** require updating the relevant `docs/` page and `AGENTS.md`.
+- **New package metadata fields** require updating the table in `docs/packages.md` and `jetson_containers/packages.py` (`_PACKAGE_KEYS`).
+- **`run.sh` changes** require updating `docs/run.md`.
+- PRs are reviewed by `@dusty-nv` and `@johnnynunez` (see `CODEOWNERS`).

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -36,9 +36,12 @@ The text between `#---` is YAML and is extracted by the build system.  Each pack
 | `group`       | `str`                | optional group the package belongs to (e.g. `ml`, `llm`, `cuda`)                        |
 | `notes`       | `str`                | brief one-line docs that are added to a package's readme table                          |
 | `path`        | `str`                | path to the package's directory (automatically populated)                               |
+| `multistage`  | `bool`               | set to `true` when the Dockerfile uses intermediate `FROM ... AS` stages; build system injects ccache/device mounts only into the final `FROM ${BASE_IMAGE}` stage |
 | `prefix`      | `str`                | text prepended to the container tag. not part of the package's name for referencing.    |
 | `postfix`     | `str`                | text appended to the container tag (default is `r$L4T_VERSION`)                         |
 | `requires`    | `str` or `list[str]` | the version(s) of L4T or CUDA the package is compatible with (e.g. `>=35.2.1` for JetPack 5.1+) |
+| `run_user`    | `str`                | the non-root username the container is designed to run as (informational; used by tooling) |
+| `secrets`     | `list[str]`          | build-time secrets the package needs; each name maps to a `JETSON_SECRET_<NAME>` env var pointing to a host file, mounted via BuildKit `--secret` and never baked into image layers |
 | `test`        | `str` or `list[str]` | one or more test commands/scripts to run (`.py`, `.sh`, or a shell command)             |
 
 > * These keys can all be accessed by any of the configuration methods below<br>

--- a/docs/run.md
+++ b/docs/run.md
@@ -56,3 +56,100 @@ If you have installed [**jetson-stats**](https://github.com/rbonghi/jetson_stats
 Check the [official documentation](https://rnext.it/jetson_stats/docker.html) for the detail.
 
 Make sure you install the same version of jetson-stats (`jtop`) both on your host and in the container.
+
+## Running as Non-Root
+
+By default all containers run as `root`. Set `DOCKER_USER` to run as a different identity:
+
+```bash
+DOCKER_USER=1000:1000 jetson-containers run $(autotag pytorch)
+# or by username (the user must exist inside the image):
+DOCKER_USER=jetson jetson-containers run $(autotag pytorch)
+```
+
+The launcher automatically adds `--group-add video --group-add audio --group-add i2c --group-add dialout --group-add plugdev` so that common hardware devices remain accessible. X11 forwarding is also updated to grant the declared user display access.
+
+### Limitations when running non-root
+
+| Feature | Root required? | Notes |
+|---------|:--------------:|-------|
+| GPU / CUDA / TensorRT | No | `--runtime nvidia` grants device access regardless of UID |
+| LLM / VLM inference | No | No hardware devices needed |
+| V4L2 cameras | No | Covered by `--group-add video` |
+| USB devices | No | Covered by `--group-add plugdev` |
+| Audio (PulseAudio) | No | Covered by `--group-add audio` |
+| I2C / serial sensors | No | Covered by `--group-add i2c` / `dialout` |
+| **CSI cameras (Argus)** | **Yes** | `nvargus-daemon` owns `/tmp/argus_socket` as root; incompatible with `DOCKER_USER` |
+| `--csi2webcam` pipeline | No (host-side) | `modprobe` runs on host; GStreamer inside container needs `video` group |
+| `/data` volume writes | Depends | Host `data/` dir must be writable by the container UID |
+| Docker socket (`docker.sock`) | No | Requires `docker` group inside image |
+
+### Building images that support non-root
+
+Pass identity at build time via env vars and consume them in the Dockerfile:
+
+```bash
+export CONTAINER_USER=jetson CONTAINER_UID=1000 CONTAINER_GID=1000
+jetson-containers build mypackage
+```
+
+These are forwarded as `--build-arg CONTAINER_USER=jetson --build-arg CONTAINER_UID=1000 --build-arg CONTAINER_GID=1000`. In the Dockerfile:
+
+```dockerfile
+ARG CONTAINER_USER=root
+ARG CONTAINER_UID=0
+ARG CONTAINER_GID=0
+
+RUN if [ "$CONTAINER_UID" != "0" ]; then \
+        groupadd -g $CONTAINER_GID $CONTAINER_USER && \
+        useradd -u $CONTAINER_UID -g $CONTAINER_GID -m $CONTAINER_USER; \
+    fi
+
+USER $CONTAINER_USER
+```
+
+Declare the supported user in package metadata so tooling can discover it:
+
+```yaml
+run_user: jetson
+```
+
+## Runtime Secrets
+
+Secrets passed as plain `--env` flags are visible in `docker inspect` output and the process list. Prefer file-backed secrets instead.
+
+### HuggingFace token
+
+```bash
+# Preferred: token stays out of docker inspect / shell history
+HUGGINGFACE_TOKEN_FILE=~/.hf_token jetson-containers run $(autotag llama3)
+
+# Fallback (backwards-compatible, token visible in docker inspect):
+HUGGINGFACE_TOKEN=hf_xxx jetson-containers run $(autotag llama3)
+```
+
+`HUGGINGFACE_TOKEN_FILE` mounts the file read-only at `/run/secrets/huggingface_token` inside the container and sets `HF_TOKEN_FILE` / `HUGGINGFACE_TOKEN_FILE` env vars pointing to it.
+
+### Build-time secrets
+
+Packages can declare secrets they need at build time. The value is never baked into an image layer:
+
+```yaml
+# in Dockerfile header or config.yaml
+secrets: [huggingface_token]
+```
+
+```bash
+export JETSON_SECRET_HUGGINGFACE_TOKEN=~/.hf_token
+jetson-containers build mypackage
+```
+
+Inside the Dockerfile, consume via `--mount=type=secret`:
+
+```dockerfile
+RUN --mount=type=secret,id=huggingface_token \
+    HF_TOKEN=$(cat /run/secrets/huggingface_token) \
+    python3 download_model.py
+```
+
+If `JETSON_SECRET_<NAME>` is not set, a warning is printed and the build continues without that secret.

--- a/docs/run.md
+++ b/docs/run.md
@@ -69,12 +69,48 @@ DOCKER_USER=jetson jetson-containers run $(autotag pytorch)
 
 The launcher automatically adds `--group-add video --group-add audio --group-add i2c --group-add dialout --group-add plugdev` so that common hardware devices remain accessible. X11 forwarding is also updated to grant the declared user display access.
 
+### GPU access as non-root (CUDA error 801)
+
+On Jetson, the GPU/Tegra device nodes are group-owned, not world-accessible:
+
+```
+$ ls -l /dev/nvhost-gpu /dev/nvmap /dev/dri/renderD128
+crw-rw---- root video  /dev/nvhost-gpu
+crw-rw---- root video  /dev/nvmap
+crw-rw---- root render /dev/dri/renderD128
+```
+
+A non-root process that is **not** a member of these groups cannot open the nodes, and CUDA fails with:
+
+```
+error 801: operation not supported
+unexpected error from cudaGetDeviceCount()
+```
+
+`jetson-containers run` fixes this automatically: when `DOCKER_USER` is set it discovers the **numeric GIDs** that own the NVIDIA/Tegra device nodes (`/dev/nvhost*`, `/dev/nvmap`, `/dev/nvgpu/*`, `/dev/dri/render*`) and adds each via `--group-add <gid>`.
+
+> **Why numeric GIDs?** The host's `render` group GID (e.g. `104`) usually does **not** match the container's `render` GID. Adding by name (`--group-add render`) would grant the wrong GID and silently fail. The numeric GID matches the bind-mounted device node exactly.
+
+If you run the container with your **own** `docker run` (not `jetson-containers run`), add the GPU device groups yourself:
+
+```bash
+# look up the GIDs that own the GPU nodes on your host:
+$ ls -ln /dev/nvhost-gpu /dev/dri/renderD128
+crw-rw---- 1 0 44  ... /dev/nvhost-gpu      # video  = 44
+crw-rw---- 1 0 104 ... /dev/dri/renderD128  # render = 104
+
+# then pass them when running as non-root:
+sudo docker run --runtime nvidia --user 1000:1000 \
+  --group-add 44 --group-add 104 \
+  -it --rm pytorch:latest python3 -c "import torch; print(torch.cuda.is_available())"
+```
+
 ### Limitations when running non-root
 
 | Feature | Root required? | Notes |
 |---------|:--------------:|-------|
-| GPU / CUDA / TensorRT | No | `--runtime nvidia` grants device access regardless of UID |
-| LLM / VLM inference | No | No hardware devices needed |
+| GPU / CUDA / TensorRT | No | Non-root needs the GPU device-node groups; `jetson-containers run` adds them automatically (see above). With your own `docker run`, add `--group-add <video-gid> --group-add <render-gid>` |
+| LLM / VLM inference | No | No hardware devices needed beyond the GPU |
 | V4L2 cameras | No | Covered by `--group-add video` |
 | USB devices | No | Covered by `--group-add plugdev` |
 | Audio (PulseAudio) | No | Covered by `--group-add audio` |

--- a/docs/run.md
+++ b/docs/run.md
@@ -120,6 +120,20 @@ sudo docker run --runtime nvidia --user 1000:1000 \
 | `/data` volume writes | Depends | Host `data/` dir must be writable by the container UID |
 | Docker socket (`docker.sock`) | No | Requires `docker` group inside image |
 
+### Running package tests as non-root
+
+Package tests (`test.py` / `test.sh`) run during `docker build`, which always executes as `root` — so the build is unaffected by non-root runtime. No package test requires actual root privileges (none use `sudo`, `apt`, `modprobe`, privileged ports, or writes to system paths).
+
+The only caveat when re-running a test at runtime under `DOCKER_USER` is that a number of tests save output artifacts under `/data` (e.g. `/data/audio/tts/`, `/data/images/`). Because `/data` is a host-mounted volume, a non-root user can only write there if the **host** `data/` directory is writable by the container UID:
+
+```bash
+# make the data cache writable by your non-root UID (one-time, on the host):
+sudo chown -R 1000:1000 jetson-containers/data
+DOCKER_USER=1000:1000 jetson-containers run $(autotag piper-tts)
+```
+
+This is a volume-ownership requirement, not a privilege requirement — CUDA and the rest of each test run fine as non-root.
+
 ### Building images that support non-root
 
 Pass identity at build time via env vars and consume them in the Dockerfile:

--- a/jetson_containers/container.py
+++ b/jetson_containers/container.py
@@ -151,8 +151,15 @@ def _prepare_buildkit_dockerfile(
         return command[:prefix_len], options, rest
 
     from_pattern = re.compile(r'^\s*FROM\s+')
+    from_intermediate_pattern = re.compile(r'^\s*FROM\s+.*\s+AS\s+\S+', re.IGNORECASE)
     run_pattern = re.compile(r'^(\s*)RUN\s+(.*)$')
     output_lines = []
+
+    # Track whether we are in the final (non-aliased) stage or an intermediate
+    # stage (FROM ... AS alias).  Only the final stage gets ccache ENV injection
+    # and RUN-level device/ccache mounts — intermediate stages (e.g. a node or
+    # cmake builder) don't need GPU access and may not have the same toolchain.
+    in_final_stage = True
 
     for line in lines:
         newline = '\n' if line.endswith('\n') else ''
@@ -160,10 +167,11 @@ def _prepare_buildkit_dockerfile(
         match = run_pattern.match(stripped_line)
 
         if from_pattern.match(stripped_line):
+            in_final_stage = not bool(from_intermediate_pattern.match(stripped_line))
             output_lines.append(line)
-            if ccache:
+            if ccache and in_final_stage:
                 output_lines.append(env_line)
-        elif match:
+        elif match and in_final_stage:
             run_options = []
 
             if device and '--device=' not in match.group(2):
@@ -343,7 +351,8 @@ def build_container(
                 user_buildkit = buildkit
                 active_buildkit_device = _normalize_buildkit_device(buildkit_device or pkg.get('buildkit_device', ''))
                 device_requested = bool(active_buildkit_device) or _dockerfile_requests_buildkit_device(dockerfilepath)
-                use_buildx = user_buildkit or scp_key_provided or bool(active_buildkit_device)
+                pkg_has_secrets = bool(pkg.get('secrets', []))
+                use_buildx = user_buildkit or scp_key_provided or bool(active_buildkit_device) or pkg_has_secrets
 
                 # Set BuildKit log size limit (default 500MB, configurable via BUILDKIT_STEP_LOG_MAX_SIZE)
                 # Default Docker BuildKit limit is 2MiB which can clip large build outputs
@@ -386,6 +395,14 @@ def build_container(
 
                 cmd += f"  --build-arg BASE_IMAGE={base}" + _NEWLINE_
                 cmd += f"  --build-arg NVIDIA_DRIVER_CAPABILITIES=all" + _NEWLINE_
+
+                # Non-root user support: pass identity args if the caller has
+                # set them via env vars so packages can create / switch to a
+                # non-root user with a stable UID/GID.
+                for arg_name in ('CONTAINER_USER', 'CONTAINER_UID', 'CONTAINER_GID'):
+                    val = os.environ.get(arg_name, '')
+                    if val:
+                        cmd += f"  --build-arg {arg_name}={val}" + _NEWLINE_
                 if use_buildx and any(cache.startswith('type=inline') for cache in cache_to):
                     cmd += f"  --build-arg BUILDKIT_INLINE_CACHE=1" + _NEWLINE_
 
@@ -406,6 +423,24 @@ def build_container(
                 # during RUN commands, never persisted in image layers)
                 if scp_key_provided:
                     cmd += f"  --secret id=scp_upload_key,src={scp_upload_key}" + _NEWLINE_
+
+                # Mount package-declared build secrets.  Each entry in the package's
+                # 'secrets' list maps to a JETSON_SECRET_<NAME> env var that must
+                # point to a readable file on the host.  The secret is exposed inside
+                # RUN steps as /run/secrets/<name> and is never baked into a layer.
+                pkg_secrets = pkg.get('secrets', [])
+                if isinstance(pkg_secrets, str):
+                    pkg_secrets = [pkg_secrets]
+                for secret_name in pkg_secrets:
+                    env_key = f"JETSON_SECRET_{secret_name.upper().replace('-', '_')}"
+                    secret_file = os.environ.get(env_key, '')
+                    if secret_file and os.path.isfile(secret_file):
+                        cmd += f"  --secret id={secret_name},src={secret_file}" + _NEWLINE_
+                    else:
+                        log_warning(
+                            f"Package '{package}' declares secret '{secret_name}' but "
+                            f"{env_key} is not set or does not point to a file — skipping"
+                        )
 
                 cmd += '   ' + pkg['path']
 

--- a/jetson_containers/packages.py
+++ b/jetson_containers/packages.py
@@ -78,8 +78,8 @@ _PACKAGE_SCAN = False
 _PACKAGE_DIRS = [os.path.join(get_repo_dir(), 'packages/*')]
 _PACKAGE_OPTS = {'check_l4t_version': True}
 _PACKAGE_KEYS = ['alias', 'build_args', 'build_flags', 'buildkit_device', 'config', 'depends', 'disabled',
-                 'dockerfile', 'docs', 'group', 'name', 'notes', 'path',
-                 'prefix', 'postfix', 'requires', 'test']
+                 'dockerfile', 'docs', 'group', 'multistage', 'name', 'notes', 'path',
+                 'prefix', 'postfix', 'requires', 'run_user', 'secrets', 'test']
 
 
 def package_search_dirs(package_dirs, scan=False):

--- a/run.sh
+++ b/run.sh
@@ -229,8 +229,11 @@ DISPLAY_DEVICE=""
 
 if [ -n "$DISPLAY" ]; then
 	echo "### DISPLAY environmental variable is already set: \"$DISPLAY\""
-	# give docker root user X11 permissions
-	xhost +si:localuser:root || sudo xhost +si:localuser:root
+	# Give X11 access to the user the container will run as.
+	# DOCKER_USER may be "uid:gid" — extract just the user portion for xhost.
+	_XHOST_USER="${DOCKER_USER%%:*}"
+	_XHOST_USER="${_XHOST_USER:-root}"
+	xhost "+si:localuser:${_XHOST_USER}" || sudo xhost "+si:localuser:${_XHOST_USER}"
 
 	# enable SSH X11 forwarding inside container (https://stackoverflow.com/q/48235040)
 	XAUTH=/tmp/.docker.xauth
@@ -266,10 +269,27 @@ if [ -n "$SCP_UPLOAD_KEY" ] && [ -f "$SCP_UPLOAD_KEY" ]; then
 	SSH_KEY_ENV="-e SCP_UPLOAD_KEY=/root/.ssh/scp_upload_key"
 fi
 
-# extra flags
-EXTRA_FLAGS=""
+# Non-root user support.
+# Set DOCKER_USER=uid:gid (e.g. "1000:1000") or a username to run the
+# container as a non-root identity.  Omit or leave empty to run as root.
+DOCKER_USER_ARG=""
+if [ -n "$DOCKER_USER" ]; then
+	DOCKER_USER_ARG="--user $DOCKER_USER"
+fi
 
-if [ -n "$HUGGINGFACE_TOKEN" ]; then
+# Runtime secrets: prefer file-backed tokens over plain env vars so values
+# are never exposed in 'docker inspect' output or the process list.
+#
+# HuggingFace token — preferred: point HUGGINGFACE_TOKEN_FILE at a file.
+# Fallback: HUGGINGFACE_TOKEN env var (value visible in docker inspect).
+EXTRA_FLAGS=""
+HF_SECRET_VOLUME=""
+
+if [ -n "$HUGGINGFACE_TOKEN_FILE" ] && [ -f "$HUGGINGFACE_TOKEN_FILE" ]; then
+	HF_SECRET_VOLUME="-v ${HUGGINGFACE_TOKEN_FILE}:/run/secrets/huggingface_token:ro"
+	EXTRA_FLAGS="$EXTRA_FLAGS --env HF_TOKEN_FILE=/run/secrets/huggingface_token"
+	EXTRA_FLAGS="$EXTRA_FLAGS --env HUGGINGFACE_TOKEN_FILE=/run/secrets/huggingface_token"
+elif [ -n "$HUGGINGFACE_TOKEN" ]; then
 	EXTRA_FLAGS="$EXTRA_FLAGS --env HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN"
 fi
 
@@ -354,6 +374,8 @@ if [ $SYSTEM_ARCH = "tegra-aarch64" ]; then
 		$PULSE_AUDIO_ARGS \
 		--device /dev/bus/usb \
 		$SSH_KEY_VOLUME $SSH_KEY_ENV \
+		$HF_SECRET_VOLUME \
+		$DOCKER_USER_ARG \
 		$OPTIONAL_PERMISSION_ARGS $DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $ACM_DEVICES $JTOP_SOCKET $EXTRA_FLAGS \
 		$CONTAINER_NAME_FLAGS \
 		"${filtered_args[@]}"
@@ -373,6 +395,8 @@ elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "x86_64" ]; then
 		--device /dev/snd \
 		$PULSE_AUDIO_ARGS \
 		$SSH_KEY_VOLUME $SSH_KEY_ENV \
+		$HF_SECRET_VOLUME \
+		$DOCKER_USER_ARG \
 		$OPTIONAL_ARGS $DATA_VOLUME $DISPLAY_DEVICE $V4L2_DEVICES $I2C_DEVICES $ACM_DEVICES $JTOP_SOCKET $EXTRA_FLAGS \
 		$CONTAINER_NAME_FLAGS \
 		"${filtered_args[@]}"

--- a/run.sh
+++ b/run.sh
@@ -263,18 +263,31 @@ SSH_KEY_VOLUME=""
 SSH_KEY_ENV=""
 
 if [ -n "$SCP_UPLOAD_KEY" ] && [ -f "$SCP_UPLOAD_KEY" ]; then
-	# Mount SSH key to a standard location in the container
-	# Mount to /root/.ssh/scp_upload_key and update the env var to point to it
-	SSH_KEY_VOLUME="-v $SCP_UPLOAD_KEY:/root/.ssh/scp_upload_key:ro"
-	SSH_KEY_ENV="-e SCP_UPLOAD_KEY=/root/.ssh/scp_upload_key"
+	# Mount SSH key under /run/secrets/ so it is accessible regardless of
+	# which user the container runs as (avoids the /root/.ssh/ ownership issue
+	# when DOCKER_USER is set to a non-root identity).
+	SSH_KEY_VOLUME="-v $SCP_UPLOAD_KEY:/run/secrets/scp_upload_key:ro"
+	SSH_KEY_ENV="-e SCP_UPLOAD_KEY=/run/secrets/scp_upload_key"
 fi
 
 # Non-root user support.
 # Set DOCKER_USER=uid:gid (e.g. "1000:1000") or a username to run the
 # container as a non-root identity.  Omit or leave empty to run as root.
+#
+# Device access: hardware devices (/dev/snd, /dev/video*, /dev/i2c-*, etc.)
+# are owned by Linux groups inside the container.  The supplementary groups
+# below are added automatically so a non-root user can still reach them.
+# All of these groups are present in standard L4T/Ubuntu base images.
+# NOTE: CSI cameras (nvargus-daemon) require root and cannot be used with
+# DOCKER_USER — see docs/run.md for details.
 DOCKER_USER_ARG=""
 if [ -n "$DOCKER_USER" ]; then
-	DOCKER_USER_ARG="--user $DOCKER_USER"
+	DOCKER_USER_ARG="--user $DOCKER_USER \
+		--group-add video \
+		--group-add audio \
+		--group-add i2c \
+		--group-add dialout \
+		--group-add plugdev"
 fi
 
 # Runtime secrets: prefer file-backed tokens over plain env vars so values

--- a/run.sh
+++ b/run.sh
@@ -275,9 +275,9 @@ fi
 # container as a non-root identity.  Omit or leave empty to run as root.
 #
 # Device access: hardware devices (/dev/snd, /dev/video*, /dev/i2c-*, etc.)
-# are owned by Linux groups inside the container.  The supplementary groups
-# below are added automatically so a non-root user can still reach them.
-# All of these groups are present in standard L4T/Ubuntu base images.
+# are owned by Linux groups inside the container.  The named supplementary
+# groups below are added automatically so a non-root user can still reach
+# them.  These GIDs match between the host and standard L4T/Ubuntu base images.
 # NOTE: CSI cameras (nvargus-daemon) require root and cannot be used with
 # DOCKER_USER — see docs/run.md for details.
 DOCKER_USER_ARG=""
@@ -288,6 +288,23 @@ if [ -n "$DOCKER_USER" ]; then
 		--group-add i2c \
 		--group-add dialout \
 		--group-add plugdev"
+
+	# GPU access for non-root users (fixes CUDA error 801, issue #1136).
+	# On Jetson the GPU/Tegra device nodes (/dev/nvhost-gpu, /dev/nvmap,
+	# /dev/nvgpu/*, /dev/dri/render*) are owned by root:video / root:render
+	# with mode 0660, so a non-root process must be a member of those groups
+	# to open them — otherwise cudaGetDeviceCount() fails with error 801.
+	#
+	# We add the *numeric* GIDs that actually own the device nodes rather than
+	# adding by name, because the host's 'render' GID frequently does NOT match
+	# the container's 'render' GID, so --group-add render would grant the wrong
+	# GID and silently fail.  Passing the numeric GID matches the bind-mounted
+	# device node exactly.  GID 0 (root-owned / world-readable nodes) is skipped.
+	GPU_DEV_GIDS=$(ls -lLn /dev/nvidia* /dev/nvhost* /dev/nvmap /dev/nvgpu/*/* /dev/dri/render* 2>/dev/null \
+		| awk 'NF>=4 && $4 ~ /^[0-9]+$/ && $4 != 0 { print $4 }' | sort -un)
+	for gid in $GPU_DEV_GIDS; do
+		DOCKER_USER_ARG="$DOCKER_USER_ARG --group-add $gid"
+	done
 fi
 
 # Runtime secrets: prefer file-backed tokens over plain env vars so values


### PR DESCRIPTION
## Summary

This PR hardens the jetson-containers build and runtime pipeline with three security improvements, and adds the project's first contribution guide.

**Closes #1136** (No GPU access while non-root user — CUDA error 801) via the non-root GPU device-group handling described below.


### Problems fixed

- **Multi-stage builds**: `_prepare_buildkit_dockerfile` injected `ENV CCACHE_DIR` and `--device=nvidia.com/gpu=all` into every `FROM` stage including intermediate compiler stages (`FROM node:22-alpine AS build`, `FROM gcc:12 AS builder`) that have no use for GPU access.
- **Non-root user**: All containers ran as root; xhost was hardcoded to `root`; SSH key was hardcoded to `/root/.ssh/` making it inaccessible for non-root users; no device group grants.
- **Secrets**: `HUGGINGFACE_TOKEN` was passed as plain `--env`, visible in `docker inspect` and the process list. No general build-time secrets mechanism beyond the hardcoded `SCP_UPLOAD_KEY`.

---

## Changes

### `jetson_containers/container.py`

**Stage-aware `_prepare_buildkit_dockerfile`** — added `in_final_stage` tracking via `from_intermediate_pattern` regex. Intermediate `FROM ... AS alias` stages are left untouched; `ENV CCACHE_DIR`, `--device`, and `--mount=type=cache` are only injected into the final `FROM ${BASE_IMAGE}` stage.

**Non-root build args** — `CONTAINER_USER`, `CONTAINER_UID`, `CONTAINER_GID` forwarded as `--build-arg` when set in the host environment.

**Package secrets** — generalises the `scp_upload_key` pattern: packages declare `secrets: [name]`; `container.py` resolves `JETSON_SECRET_<NAME>` env vars to host files and mounts them via BuildKit `--secret` (never baked into layers). BuildKit is auto-enabled when secrets are declared.

### `jetson_containers/packages.py`

Added `multistage`, `run_user`, and `secrets` to `_PACKAGE_KEYS`.

### `run.sh`

| Fix | Detail |
|-----|--------|
| SSH key path | `/root/.ssh/scp_upload_key` → `/run/secrets/scp_upload_key` — accessible regardless of container user |
| Device group grants | `--group-add video audio i2c dialout plugdev` added automatically when `DOCKER_USER` is set |
| xhost | Grants X11 access to `DOCKER_USER` instead of hardcoded `root` |
| File-backed HF token | `HUGGINGFACE_TOKEN_FILE=~/.hf_token` mounts file at `/run/secrets/huggingface_token`; never in `docker inspect` |
| HF token fallback | `HUGGINGFACE_TOKEN` env var still works for backwards compatibility |

### Documentation

| File | What is new |
|------|------------|
| `docs/packages.md` | `multistage`, `run_user`, `secrets` added to the metadata key table |
| `docs/run.md` | **Running as Non-Root** section (DOCKER_USER, device group table, CSI root limitation, build-time identity pattern) and **Runtime Secrets** section |
| `AGENTS.md` | **Security Features** section with Dockerfile examples for all three features |
| `CONTRIBUTING.md` | **New file** — first contribution guide: package authoring, multi-stage pattern, non-root support, secrets, dynamic version configs, code style, testing, PR guidelines |

---

## Non-Root Limitations

CSI cameras (`nvargus-daemon`) require root by design — the daemon socket is root-owned. All other device types work via `--group-add`.

| Feature | Works non-root? |
|---------|:--------------:|
| GPU / CUDA / TensorRT | ✅ |
| LLM / VLM / vision inference | ✅ |
| V4L2, USB, audio, I2C, serial | ✅ (via `--group-add`) |
| CSI cameras (Argus / nvargus-daemon) | ❌ root required |

---

## Usage

```bash
# Non-root runtime
DOCKER_USER=1000:1000 jetson-containers run $(autotag pytorch)

# File-backed HF token (preferred over env var)
HUGGINGFACE_TOKEN_FILE=~/.hf_token jetson-containers run $(autotag llama3)

# Build with non-root identity
CONTAINER_USER=jetson CONTAINER_UID=1000 CONTAINER_GID=1000 jetson-containers build mypackage

# Build-time secret
JETSON_SECRET_HUGGINGFACE_TOKEN=~/.hf_token jetson-containers build mypackage
```

Multi-stage Dockerfile pattern:
```dockerfile
#---
# name: mypackage
# multistage: true
#---
ARG BASE_IMAGE
FROM gcc:12 AS builder       # no ccache/device injection
RUN make -j$(nproc)

FROM ${BASE_IMAGE}           # ccache + device mounts injected here only
COPY --from=builder /out /usr/local
RUN ldconfig
```

---

## Test Plan

- [x] Stage-aware multi-stage: intermediate `FROM...AS` gets no `ENV CCACHE_DIR`, `--device`, or ccache mounts
- [x] Single-stage regression: both `RUN` lines still get full injection
- [x] Three-stage (2 intermediate + 1 final): only final stage gets injection
- [x] `_PACKAGE_KEYS` contains `secrets`, `run_user`, `multistage`
- [x] `validate_dict` accepts packages with new fields
- [x] Secrets injection: `--secret` flag for set secrets; warning for missing
- [x] `run.sh` `bash -n` syntax check passes
- [x] `DOCKER_USER_ARG`, `HF_SECRET_VOLUME`, `HUGGINGFACE_TOKEN_FILE` wired into both Tegra and x86 `docker run` paths
- [x] Import smoke test

> **Pre-existing failures:** `tests/verify_triton_config.py` has 2 stale version expectations that fail on `master` before this branch. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)