### PR TITLE
Fix #1575: install Python interpreter to /opt/python so non-root users can access it

### DIFF
--- a/packages/build/python/Dockerfile
+++ b/packages/build/python/Dockerfile
@@ -28,7 +28,8 @@ ENV PYTHON_VERSION=${PYTHON_VERSION} \
     TWINE_NON_INTERACTIVE=1 \
     DEBIAN_FRONTEND=noninteractive \
     PATH=/opt/venv/bin:$PATH \
-    UV_PYTHON=/opt/venv/bin/python
+    UV_PYTHON=/opt/venv/bin/python \
+    UV_PYTHON_INSTALL_DIR=/opt/python
 
 #PYTHONPATH=/opt/venv/lib/python${PYTHON_VERSION_ARG}/site-packages:/usr/lib/python3/dist-packages:$PYTHONPATH \
 

--- a/packages/build/python/install.sh
+++ b/packages/build/python/install.sh
@@ -35,14 +35,23 @@ if [ -f "${HOME}/.local/bin/uv" ]; then
   install -m 0755 "${HOME}/.local/bin/uv" /usr/local/bin/uv
 fi
 
-# Install the requested Python version via uv
+# Install the requested Python version via uv.
+# Use a world-readable install dir instead of the default ($HOME/.local/share/uv/python),
+# which lands under /root (mode 0700) and makes the interpreter inaccessible to
+# non-root users in the container (the /opt/venv symlinks point back into /root).
+# See https://github.com/dusty-nv/jetson-containers/issues/1575
+export UV_PYTHON_INSTALL_DIR=/opt/python
 uv python install "${PYTHON_INSTALL_VERSION}"
 
-# Find the path to that Python version
+# Find the path to that Python version (also reads UV_PYTHON_INSTALL_DIR)
 PY_BIN="$(uv python find "${PYTHON_INSTALL_VERSION}")"
 
 # Create a virtual environment in /opt/venv
 uv venv --python "${PY_BIN}" --system-site-packages /opt/venv
+
+# Ensure the interpreter and venv are traversable/readable by non-root users,
+# regardless of the build environment's umask (defensive; uv defaults to 0755).
+chmod -R a+rX /opt/python /opt/venv
 
 # Activate the venv
 . /opt/venv/bin/activate


### PR DESCRIPTION
Fixes #1575

## Problem

The `python` package installs the interpreter with `uv python install`, which uses uv's default install directory `$HOME/.local/share/uv/python`. During the build `$HOME` is `/root`, so the interpreter lands in `/root/.local/share/uv/python/...`. The `/opt/venv` virtualenv then symlinks its `bin/python` back to that interpreter:

```
/opt/venv/bin/python  ->  /root/.local/share/uv/python/cpython-3.x.../bin/python3.x
```

`/root` is mode `0700`, so **any non-root user in the container cannot traverse into it** — the symlinked interpreter, and therefore `python` itself, is inaccessible no matter the permission bits on the interpreter. This blocks running the containers as a non-root user (reported in #1575).

### Root cause confirmed

```
$ stat -c '%a' /root
700
```

`namei` traversal of the symlink target shows the barrier — the path passes through a `0700` directory (`/root`) that non-root users cannot enter:

```
BEFORE:  /opt/venv/bin/python -> .../root_home/.../python3.12
         drwx------  root_home          <-- 0700, blocks non-root traversal

AFTER:   /opt/venv/bin/python -> .../opt_python/.../python3.12
         drwxr-xr-x  opt_python         <-- 0755, traversable by all
```

## Fix

Set `UV_PYTHON_INSTALL_DIR=/opt/python` before `uv python install` / `uv python find` so the interpreter is placed in a world-traversable location. The `/opt/venv` symlinks then resolve through `/opt/python` (`0755`) instead of `/root` (`0700`).

- **`packages/build/python/install.sh`** — export `UV_PYTHON_INSTALL_DIR=/opt/python` before the `uv python install`/`find` calls (both honor the env var); add a defensive `chmod -R a+rX /opt/python /opt/venv` in case the build environment has an unusual umask.
- **`packages/build/python/Dockerfile`** — persist `UV_PYTHON_INSTALL_DIR=/opt/python` in the `ENV` block so any runtime `uv` invocation resolves the same location.

This matches the fix suggested by the issue reporter, using the `UV_PYTHON_INSTALL_DIR` env var (cleaner than `--install-dir`, and it is honored by both `uv python install` and `uv python find`).

## Test Plan

- [x] `bash -n packages/build/python/install.sh` — syntax valid
- [x] Confirmed `/root` is mode `0700` on the host (the premise of the bug)
- [x] `namei -l` traversal demonstrates the `0700` barrier disappears when the interpreter moves to `/opt/python` (`0755`)
- [x] **Full container build verification** — built images running the real `install.sh` and ran `python3` as a non-root user. The fixed build succeeds; the pre-fix build (fix removed) fails at the non-root step, reproducing the bug:

```
  AFTER  (fixed)   build exit code: 0   (expected 0)
  BEFORE (pre-fix) build exit code: 1   (expected non-zero)

  ✓ fixed install.sh: non-root user can run python
  ✓ pre-fix install.sh: non-root access fails as expected (bug reproduced)

OVERALL: PASS — issue #1575 is fixed.
```

<details>
<summary>Reproduce it yourself</summary>

Build two images that run the real `install.sh`, then create a non-root user and run `python3` as them. The non-root `RUN python3 ...` is the assertion — if the interpreter is unreachable the build aborts with "Permission denied":

```bash
WORK=$(mktemp -d)
cp packages/build/python/install.sh "$WORK/install-after.sh"
# pre-fix control: strip the two fix lines
sed -e '/export UV_PYTHON_INSTALL_DIR=\/opt\/python/d' \
    -e '/chmod -R a+rX \/opt\/python \/opt\/venv/d' \
    packages/build/python/install.sh > "$WORK/install-before.sh"

cat > "$WORK/Dockerfile" <<'EOF'
ARG BASE_IMAGE=ubuntu:22.04
FROM ${BASE_IMAGE}
ARG INSTALL_SCRIPT=install-after.sh
ENV PYTHON_VERSION=3.12
RUN apt-get update && apt-get install -y --no-install-recommends \
      curl ca-certificates build-essential && rm -rf /var/lib/apt/lists/*
COPY ${INSTALL_SCRIPT} /tmp/install.sh
RUN bash /tmp/install.sh
RUN useradd -m -u 1000 appuser
USER appuser
RUN python3 -c "import sys; print('non-root sys.executable =', sys.executable)"
EOF

sudo docker build --build-arg INSTALL_SCRIPT=install-after.sh  -t jc1575-after  "$WORK"  # expect SUCCESS
sudo docker build --build-arg INSTALL_SCRIPT=install-before.sh -t jc1575-before "$WORK"  # expect FAILURE
```

Or on the real Jetson base image: `jetson-containers build python`, then
`sudo docker run --rm --user 1000:1000 $(autotag python) python3 -c "import sys; print(sys.executable)"`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)